### PR TITLE
fix: Preserve symlinks while zipping and unzipping

### DIFF
--- a/data/testsymlink/bar/test
+++ b/data/testsymlink/bar/test
@@ -1,0 +1,1 @@
+contents

--- a/data/testsymlink/symlink
+++ b/data/testsymlink/symlink
@@ -1,0 +1,1 @@
+bar/test

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -1,10 +1,8 @@
 package sdstore
 
 import (
-	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"github.com/mholt/archiver"
 	"io"
 	"io/ioutil"
 	"log"
@@ -203,7 +201,7 @@ func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 			}
 
 			absPath, _ := filepath.Abs(filePath)
-			err = archiver.Zip.Make(zipPath, []string{absPath})
+			err = Zip(absPath, zipPath)
 			if err != nil {
 				log.Printf("(Try %d of %d) Unable to zip file: %v", i+1, maxRetries, err)
 				continue
@@ -404,63 +402,4 @@ func (s *sdStore) put(url *url.URL, bodyType string, payload io.Reader, size int
 	}
 
 	return handleResponse(res)
-}
-
-// Taken from https://golangcode.com/unzip-files-in-go/
-func Unzip(src string, dest string) ([]string, error) {
-	var filenames []string
-
-	r, err := zip.OpenReader(src)
-	if err != nil {
-		return filenames, err
-	}
-	defer r.Close()
-
-	for _, f := range r.File {
-
-		rc, err := f.Open()
-		if err != nil {
-			return filenames, err
-		}
-		defer rc.Close()
-
-		// Store filename/path for returning and using later on
-		fpath := filepath.Join(dest, f.Name)
-
-		// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
-		if dest != "/" && !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
-			return filenames, fmt.Errorf("%s: illegal file path", fpath)
-		}
-
-		filenames = append(filenames, fpath)
-
-		if f.FileInfo().IsDir() {
-
-			// Make Folder
-			os.MkdirAll(fpath, os.ModePerm)
-
-		} else {
-
-			// Make File
-			if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
-				return filenames, err
-			}
-
-			outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-			if err != nil {
-				return filenames, err
-			}
-
-			_, err = io.Copy(outFile, rc)
-
-			// Close the file without defer to close before next iteration of loop
-			outFile.Close()
-
-			if err != nil {
-				return filenames, err
-			}
-
-		}
-	}
-	return filenames, nil
 }

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -576,3 +576,29 @@ func TestRemoveRetry(t *testing.T) {
 		t.Errorf("Expected 6 retries, got %d", callCount)
 	}
 }
+
+func TestZipAndUnzipWithSymlink(t *testing.T) {
+	err := Zip("../data/testsymlink", "../data/testsymlink.zip")
+
+	if err != nil {
+		t.Errorf("Unable to zip file")
+	}
+
+	_, err = Unzip("../data/testsymlink.zip", "../data/test")
+
+	if err != nil {
+		t.Errorf("Unable to unzip file %v", err)
+	}
+
+	fi, err := os.Readlink("../data/test/testsymlink/symlink")
+	if err != nil {
+		t.Errorf("Could not read symbolic link: %v", err)
+	}
+
+	if fi != "bar/test" {
+		t.Errorf("Expected symlink to point to bar/test, got %s", fi)
+	}
+
+	os.RemoveAll("../data/test")
+	os.RemoveAll("../data/testsymlink.zip")
+}

--- a/sdstore/ziphelper.go
+++ b/sdstore/ziphelper.go
@@ -1,0 +1,200 @@
+package sdstore
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+var compressedFormats = map[string]struct{}{
+	".7z":   {},
+	".avi":  {},
+	".bz2":  {},
+	".cab":  {},
+	".gif":  {},
+	".gz":   {},
+	".jar":  {},
+	".jpeg": {},
+	".jpg":  {},
+	".lz":   {},
+	".lzma": {},
+	".mov":  {},
+	".mp3":  {},
+	".mp4":  {},
+	".mpeg": {},
+	".mpg":  {},
+	".png":  {},
+	".rar":  {},
+	".tbz2": {},
+	".tgz":  {},
+	".txz":  {},
+	".xz":   {},
+	".zip":  {},
+	".zipx": {},
+}
+
+// Repurposed from https://github.com/mholt/archiver/pull/92/files
+// To include support for symbolic links
+func Zip(source, target string) error {
+	zipfile, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer zipfile.Close()
+
+	w := zip.NewWriter(zipfile)
+	defer w.Close()
+
+	sourceInfo, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("%s: stat: %v", source, err)
+	}
+
+	var baseDir string
+	if sourceInfo.IsDir() {
+		baseDir = filepath.Base(source)
+	}
+
+	return filepath.Walk(source, func(fpath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("walking to %s: %v", fpath, err)
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return fmt.Errorf("%s: getting header: %v", fpath, err)
+		}
+
+		if baseDir != "" {
+			name, err := filepath.Rel(source, fpath)
+			if err != nil {
+				return err
+			}
+			header.Name = path.Join(baseDir, filepath.ToSlash(name))
+		}
+
+		if info.IsDir() {
+			header.Name += "/"
+			header.Method = zip.Store
+		} else {
+			ext := strings.ToLower(path.Ext(header.Name))
+			if _, ok := compressedFormats[ext]; ok {
+				header.Method = zip.Store
+			} else {
+				header.Method = zip.Deflate
+			}
+		}
+
+		writer, err := w.CreateHeader(header)
+		if err != nil {
+			return fmt.Errorf("%s: making header: %v", fpath, err)
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if (header.Mode() & os.ModeSymlink) != 0 {
+			linkTarget, err := os.Readlink(fpath)
+			if err != nil {
+				return fmt.Errorf("%s: readlink: %v", fpath, err)
+			}
+			_, err = writer.Write([]byte(filepath.ToSlash(linkTarget)))
+			if err != nil {
+				return fmt.Errorf("%s: writing symlink target: %v", fpath, err)
+			}
+			return nil
+		}
+
+		if header.Mode().IsRegular() {
+			file, err := os.Open(fpath)
+			if err != nil {
+				return fmt.Errorf("%s: opening: %v", fpath, err)
+			}
+			defer file.Close()
+
+			_, err = io.CopyN(writer, file, info.Size())
+			if err != nil && err != io.EOF {
+				return fmt.Errorf("%s: copying contents: %v", fpath, err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// Repurposed from https://github.com/mholt/archiver/pull/92/files
+// To include support for symbolic links
+func Unzip(src string, dest string) ([]string, error) {
+	var filenames []string
+
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return filenames, err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+
+		rc, err := f.Open()
+		if err != nil {
+			return filenames, err
+		}
+		defer rc.Close()
+
+		// Store filename/path for returning and using later on
+		fpath := filepath.Join(dest, f.Name)
+
+		// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
+		if dest != "/" && !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return filenames, fmt.Errorf("%s: illegal file path", fpath)
+		}
+
+		filenames = append(filenames, fpath)
+
+		if f.FileInfo().IsDir() {
+
+			// Make Folder
+			os.MkdirAll(fpath, os.ModePerm)
+		} else if (f.FileInfo().Mode() & os.ModeSymlink) != 0 {
+			buffer := make([]byte, f.FileInfo().Size())
+			size, err := rc.Read(buffer)
+			if err != nil && err != io.EOF {
+				return filenames, err
+			}
+
+			target := string(buffer[:size])
+
+			err = os.Symlink(target, fpath)
+			if err != nil {
+				return filenames, err
+			}
+		} else {
+
+			// Make File
+			if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+				return filenames, err
+			}
+
+			outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return filenames, err
+			}
+
+			_, err = io.Copy(outFile, rc)
+
+			// Close the file without defer to close before next iteration of loop
+			outFile.Close()
+
+			if err != nil {
+				return filenames, err
+			}
+
+		}
+	}
+	return filenames, nil
+}


### PR DESCRIPTION
Currently, the archiver library doesn't support preserving symlinks and this breaks users who cache `node_modules` and run stuff like `npm publish`. This PR repurposes some code from https://github.com/mholt/archiver/pull/92/files to fix this problem.