### PR TITLE
[4] fix: use pr parent job id for pr cache

### DIFF
--- a/store-cli.go
+++ b/store-cli.go
@@ -48,9 +48,10 @@ func skipCache(storeType, scope, action string) bool {
 	}
 
 	// For PR jobs,
-	// skip PR event cache to save time, since PR event only consists of 1 job
+	// skip event cache to save time, since PR event only consists of 1 job
 	// skip pipeline scoped unless it's trying to get
-	if scope == "event" || (scope == "pipeline" && action != "get") {
+	// skip job scoped unless it's trying to get
+	if scope == "event" || (action != "get" && (scope == "pipeline" || scope == "job")) {
 		log.Printf("Skipping %s %s-scoped cache for Pull Request", action, scope)
 		return true
 	}

--- a/store-cli.go
+++ b/store-cli.go
@@ -66,7 +66,12 @@ func makeURL(storeType, scope, key string) (*url.URL, error) {
 	case "event":
 		scopeEnv = os.Getenv("SD_EVENT_ID")
 	case "job":
-		scopeEnv = os.Getenv("SD_JOB_ID")
+		// use real job id if current job is a PR
+		if os.Getenv("SD_PULL_REQUEST") != "" && os.Getenv("SD_PR_PARENT_JOB_ID") != "" {
+			scopeEnv = os.Getenv("SD_PR_PARENT_JOB_ID")
+		} else {
+			scopeEnv = os.Getenv("SD_JOB_ID")
+		}
 	case "pipeline":
 		scopeEnv = os.Getenv("SD_PIPELINE_ID")
 	}

--- a/store-cli_test.go
+++ b/store-cli_test.go
@@ -32,7 +32,7 @@ func TestSkipCache(t *testing.T) {
 		{"cache", "event", "get", "123", true},
 		{"cache", "event", "set", "123", true},
 		{"cache", "job", "get", "", false},
-		{"cache", "job", "set", "123", false},
+		{"cache", "job", "set", "123", true},
 		{"artifact", "event", "get", "", false},
 		{"log", "build", "set", "123", false},
 	}

--- a/store-cli_test.go
+++ b/store-cli_test.go
@@ -49,6 +49,7 @@ func TestSkipCache(t *testing.T) {
 func TestMakeURL(t *testing.T) {
 	os.Setenv("SD_STORE_URL", "http://store.screwdriver.cd/v1/")
 	os.Setenv("SD_BUILD_ID", "10038")
+	os.Setenv("SD_JOB_ID", "888")
 	os.Setenv("SD_EVENT_ID", "499")
 	os.Setenv("SD_PIPELINE_ID", "100")
 	abspath, _ := filepath.Abs("./")
@@ -61,6 +62,7 @@ func TestMakeURL(t *testing.T) {
 		key       string
 		expected  string
 	}{
+		{"cache", "job", "/myprcache", "http://store.screwdriver.cd/v1/caches/jobs/987/%2Fmyprcache"},
 		{"cache", "event", "/mycache", "http://store.screwdriver.cd/v1/caches/events/499/%2Fmycache"},
 		{"cache", "event", "mycache", fmt.Sprintf("%s%s%s", "http://store.screwdriver.cd/v1/caches/events/499/", abspath, "%2Fmycache")},
 		{"cache", "event", "./mycache", fmt.Sprintf("%s%s%s", "http://store.screwdriver.cd/v1/caches/events/499/", abspath, "%2Fmycache")},
@@ -74,6 +76,10 @@ func TestMakeURL(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		if tc.key == "/myprcache" {
+			os.Setenv("SD_PULL_REQUEST", "900")
+			os.Setenv("SD_PR_PARENT_JOB_ID", "987")
+		}
 		i, _ := makeURL(tc.storeType, tc.scope, tc.key)
 		if i.String() != tc.expected {
 			t.Fatalf("Expected '%s' got '%s'", tc.expected, i)


### PR DESCRIPTION
Blocked By:
- https://github.com/screwdriver-cd/data-schema/pull/297/files
- https://github.com/screwdriver-cd/models/pull/302
- New API deployment
- https://github.com/screwdriver-cd/launcher/pull/242

Related: https://github.com/screwdriver-cd/screwdriver/issues/1382