### PR TITLE
fix: trim correctly

### DIFF
--- a/store-cli.go
+++ b/store-cli.go
@@ -89,7 +89,7 @@ func makeURL(storeType, scope, key string) (*url.URL, error) {
 		encoded := url.QueryEscape(key)
 		path = "caches/" + scope + "s/" + scopeEnv + "/" + encoded
 	case "artifact":
-		key = strings.TrimLeft(key, "./")
+		key = strings.TrimPrefix(key, "./")
 		encoded := url.QueryEscape(key)
 		path = "builds/" + os.Getenv("SD_BUILD_ID") + "/ARTIFACTS/" + encoded
 	case "log":

--- a/store-cli_test.go
+++ b/store-cli_test.go
@@ -70,6 +70,7 @@ func TestMakeURL(t *testing.T) {
 		{"cache", "event", "/!-_.*'()&@:,.$=+?; space", "http://store.screwdriver.cd/v1/caches/events/499/%2F%21-_.%2A%27%28%29%26%40%3A%2C.%24%3D%2B%3F%3B+space"},
 		{"artifact", "event", "artifact-1", "http://store.screwdriver.cd/v1/builds/10038/ARTIFACTS/artifact-1"},
 		{"artifact", "build", "test", "http://store.screwdriver.cd/v1/builds/10038/ARTIFACTS/test"},
+		{"artifact", "", ".test", "http://store.screwdriver.cd/v1/builds/10038/ARTIFACTS/.test"},
 		{"artifact", "", "./test", "http://store.screwdriver.cd/v1/builds/10038/ARTIFACTS/test"},
 		{"artifact", "", "test/foo", "http://store.screwdriver.cd/v1/builds/10038/ARTIFACTS/test%2Ffoo"},
 		{"artifact", "", "test/foo./bar", "http://store.screwdriver.cd/v1/builds/10038/ARTIFACTS/test%2Ffoo.%2Fbar"},


### PR DESCRIPTION
This PR fix to use `TrimPrefx` to trim `./` prefix from path string.

I missunderstood the usage of trim.
https://golang.org/pkg/strings/#TrimLeft
> TrimLeft returns a slice of the string s with all leading Unicode code points contained in cutset removed.
> To remove a prefix, use TrimPrefix instead.

```
$ cat test.go
package main

import (
	"fmt"
	"strings"
)

func main() {
	fmt.Println("TrimLeft:   expected sd/file,  actual", strings.TrimLeft("./sd/file", "./"))
	fmt.Println("TrimLeft:   expected .sd/file, actual", strings.TrimLeft(".sd/file", "./"))
	fmt.Println("TrimPrefix: expected sd/file,  actual", strings.TrimPrefix("./sd/file", "./"))
	fmt.Println("TrimPrefix: expected .sd/file, actual", strings.TrimPrefix(".sd/file", "./"))
}
$ go run test.go
TrimLeft:   expected sd/file,  actual sd/file
TrimLeft:   expected .sd/file, actual sd/file
TrimPrefix: expected sd/file,  actual sd/file
TrimPrefix: expected .sd/file, actual .sd/file
```