### PR TITLE
fix: not to retry when status is 404

### DIFF
--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -402,10 +402,10 @@ func (s *sdStore) checkForRetry(res *http.Response, err error) bool {
 	if err != nil {
 		return true
 	}
-	if res.StatusCode == 0 || res.StatusCode >= 500 {
-		return true
+	if res.StatusCode == http.StatusNotFound {
+		return false
 	}
-	return false
+	return true
 }
 
 func (s *sdStore) do(req *http.Request) (*http.Response, error) {

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -16,10 +16,6 @@ import (
 	"time"
 )
 
-var retryScaler = 1.0
-
-const maxRetries = 3
-
 // SDStore is able to upload, download, and remove the contents of a Reader to the SD Store
 type SDStore interface {
 	Upload(u *url.URL, filePath string, toCompress bool) error
@@ -28,15 +24,19 @@ type SDStore interface {
 }
 
 type sdStore struct {
-	token  string
-	client *http.Client
+	token       string
+	client      *http.Client
+	retryScaler float64
+	maxRetries  int
 }
 
 // NewStore returns an SDStore instance.
 func NewStore(token string) SDStore {
 	return &sdStore{
-		token,
-		&http.Client{Timeout: 300 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 300 * time.Second},
+		retryScaler: 1.0,
+		maxRetries:  3,
 	}
 }
 
@@ -77,12 +77,12 @@ func (e SDError) Error() string {
 // Remove a file from a path within the SD Store
 func (s *sdStore) Remove(u *url.URL) error {
 	var err error
-	for i := 0; i < maxRetries; i++ {
-		time.Sleep(time.Duration(float64(i*i)*retryScaler) * time.Second)
+	for i := 0; i < s.maxRetries; i++ {
+		time.Sleep(time.Duration(float64(i*i)*s.retryScaler) * time.Second)
 
 		_, err := s.remove(u)
 		if err != nil {
-			log.Printf("(Try %d of %d) error received from file removal: %v", i+1, maxRetries, err)
+			log.Printf("(Try %d of %d) error received from file removal: %v", i+1, s.maxRetries, err)
 			continue
 		}
 
@@ -90,28 +90,18 @@ func (s *sdStore) Remove(u *url.URL) error {
 
 		return nil
 	}
-	return fmt.Errorf("removing from %s after %d retries: %v", u, maxRetries, err)
+	return fmt.Errorf("removing from %s after %d retries: %v", u, s.maxRetries, err)
 }
 
 // Download a file from a path within the SD Store
 func (s *sdStore) Download(url *url.URL, toExtract bool) ([]byte, error) {
-	var err error
-
-	for i := 0; i < maxRetries; i++ {
-		time.Sleep(time.Duration(float64(i*i)*retryScaler) * time.Second)
-
-		res, err := s.get(url, toExtract)
-		if err != nil {
-			log.Printf("(Try %d of %d) error received from file download: %v", i+1, maxRetries, err)
-			continue
-		}
-
-		log.Printf("Download from %s successful.", url.String())
-
-		return res, nil
+	res, err := s.get(url, toExtract)
+	if err != nil {
+		return nil, err
 	}
+	log.Printf("Download from %s successful.", url.String())
 
-	return nil, fmt.Errorf("getting from %s after %d retries: %v", url, maxRetries, err)
+	return res, nil
 }
 
 func (s *sdStore) GenerateAndCheckMd5Json(url *url.URL, path string) (string, error) {
@@ -167,8 +157,8 @@ func (s *sdStore) GenerateAndCheckMd5Json(url *url.URL, path string) (string, er
 func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 	var err error
 
-	for i := 0; i < maxRetries; i++ {
-		time.Sleep(time.Duration(float64(i*i)*retryScaler) * time.Second)
+	for i := 0; i < s.maxRetries; i++ {
+		time.Sleep(time.Duration(float64(i*i)*s.retryScaler) * time.Second)
 
 		if toCompress {
 			var fileName string
@@ -182,13 +172,13 @@ func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 			}
 
 			if err != nil {
-				log.Printf("(Try %d of %d) error received from generating md5: %v", i+1, maxRetries, err)
+				log.Printf("(Try %d of %d) error received from generating md5: %v", i+1, s.maxRetries, err)
 				continue
 			}
 
 			err = s.putFile(encodedURL, "application/json", md5Json)
 			if err != nil {
-				log.Printf("(Try %d of %d) error received from uploading md5 json: %v", i+1, maxRetries, err)
+				log.Printf("(Try %d of %d) error received from uploading md5 json: %v", i+1, s.maxRetries, err)
 				continue
 			}
 
@@ -201,14 +191,14 @@ func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 			zipPath, err = filepath.Abs(fmt.Sprintf("%s.zip", fileName))
 
 			if err != nil {
-				log.Printf("(Try %d of %d) Unable to determine filepath: %v", i+1, maxRetries, err)
+				log.Printf("(Try %d of %d) Unable to determine filepath: %v", i+1, s.maxRetries, err)
 				continue
 			}
 
 			absPath, _ := filepath.Abs(filePath)
 			err = Zip(absPath, zipPath)
 			if err != nil {
-				log.Printf("(Try %d of %d) Unable to zip file: %v", i+1, maxRetries, err)
+				log.Printf("(Try %d of %d) Unable to zip file: %v", i+1, s.maxRetries, err)
 				continue
 			}
 
@@ -217,7 +207,7 @@ func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 			errRemove := os.Remove(zipPath)
 
 			if err != nil {
-				log.Printf("(Try %d of %d) error received from file upload: %v", i+1, maxRetries, err)
+				log.Printf("(Try %d of %d) error received from file upload: %v", i+1, s.maxRetries, err)
 				continue
 			}
 
@@ -231,14 +221,14 @@ func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 		} else {
 			err := s.putFile(u, "text/plain", filePath)
 			if err != nil {
-				log.Printf("(Try %d of %d) error received from file upload: %v", i+1, maxRetries, err)
+				log.Printf("(Try %d of %d) error received from file upload: %v", i+1, s.maxRetries, err)
 				continue
 			}
 			log.Printf("Upload to %s successful.", u.String())
 			return nil
 		}
 	}
-	return fmt.Errorf("posting to %s after %d retries: %v", filePath, maxRetries, err)
+	return fmt.Errorf("posting to %s after %d retries: %v", filePath, s.maxRetries, err)
 }
 
 // token header for request
@@ -301,17 +291,11 @@ func (s *sdStore) get(url *url.URL, toExtract bool) ([]byte, error) {
 	}
 
 	req.Header.Set("Authorization", tokenHeader(s.token))
-
-	res, err := s.client.Do(req)
+	res, err := s.do(req)
 	if err != nil {
 		return nil, err
 	}
-
 	defer res.Body.Close()
-
-	if res.StatusCode/100 == 5 {
-		return nil, fmt.Errorf("response code %d", res.StatusCode)
-	}
 
 	body, err := handleResponse(res)
 	if err != nil {
@@ -408,4 +392,37 @@ func (s *sdStore) put(url *url.URL, bodyType string, payload io.Reader, size int
 	}
 
 	return handleResponse(res)
+}
+
+func (s *sdStore) backOff(attemptNum int) time.Duration {
+	return time.Duration(float64(attemptNum*attemptNum)*s.retryScaler) * time.Second
+}
+
+func (s *sdStore) checkForRetry(res *http.Response, err error) bool {
+	if err != nil {
+		return true
+	}
+	if res.StatusCode == 0 || res.StatusCode >= 500 {
+		return true
+	}
+	return false
+}
+
+func (s *sdStore) do(req *http.Request) (*http.Response, error) {
+	attemptNum := 0
+	for {
+		attemptNum := attemptNum + 1
+		res, err := s.client.Do(req)
+		retry := s.checkForRetry(res, err)
+		log.Printf("(Try %d of %d) error received from file removal: %v", attemptNum, s.maxRetries, err)
+		if !retry {
+			return res, err
+		}
+		remain := s.maxRetries - 1
+		if remain == 0 {
+			break
+		}
+		time.Sleep(s.backOff(attemptNum))
+	}
+	return nil, fmt.Errorf("getting from %s after %d retries", req.URL, s.maxRetries)
 }

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -405,9 +405,9 @@ func (s *sdStore) checkForRetry(res *http.Response, err error) (bool, error) {
 	}
 	if res.StatusCode == http.StatusNotFound {
 		if res.Request != nil && res.Request.URL != nil {
-			return false, fmt.Errorf("got %s from %s. stop retring", res.Status, res.Request.URL)
+			return false, fmt.Errorf("got %s from %s. stop retrying", res.Status, res.Request.URL)
 		}
-		return false, fmt.Errorf("got %s. stop retring", res.Status)
+		return false, fmt.Errorf("got %s. stop retrying", res.Status)
 	}
 
 	if res.StatusCode/100 != 2 {

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -423,7 +423,7 @@ func (s *sdStore) do(req *http.Request) (*http.Response, error) {
 		attemptNum = attemptNum + 1
 		res, err := s.client.Do(req)
 		retry, err := s.checkForRetry(res, err)
-		log.Printf("(Try %d of %d) error received from file removal: %v", attemptNum, s.maxRetries, err)
+		log.Printf("(Try %d of %d) error received from %s %v: %v", attemptNum, s.maxRetries, req.Method, req.URL, err)
 		if !retry {
 			return res, err
 		}

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -12,7 +12,18 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func newStore(retryScaler float64, maxRetries int) *sdStore {
+	return &sdStore{
+		token:       "faketoken",
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: retryScaler,
+		maxRetries:  maxRetries,
+	}
+}
 
 func validateHeader(t *testing.T, key, value string) func(r *http.Request) {
 	return func(r *http.Request) {
@@ -112,8 +123,10 @@ func TestUpload(t *testing.T) {
 	token := "faketoken"
 	u, _ := url.Parse("http://fakestore.com/builds/emitterdata")
 	uploader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: 1.0,
+		maxRetries:  3,
 	}
 	called := false
 
@@ -159,8 +172,10 @@ func TestUploadZipWithChange(t *testing.T) {
 	zipfile := file + ".zip"
 	u, _ := url.Parse("http://fakestore.com/v1/caches/events/123/" + file)
 	uploader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: 1.0,
+		maxRetries:  3.0,
 	}
 	called := 0
 	getMd5 := false
@@ -259,8 +274,10 @@ func TestUploadZipNoChange(t *testing.T) {
 	file := "../data/emitterdata2"
 	u, _ := url.Parse("http://fakestore.com/v1/caches/events/123/" + file)
 	uploader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: 1.0,
+		maxRetries:  3.0,
 	}
 	called := 0
 
@@ -291,12 +308,13 @@ func TestUploadZipNoChange(t *testing.T) {
 }
 
 func TestUploadRetry(t *testing.T) {
-	retryScaler = .01
 	token := "faketoken"
 	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
 	uploader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: .01,
+		maxRetries:  3.0,
 	}
 
 	callCount := 0
@@ -314,12 +332,13 @@ func TestUploadRetry(t *testing.T) {
 }
 
 func TestUploadZipRetry(t *testing.T) {
-	retryScaler = .01
 	token := "faketoken"
 	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
 	uploader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: .01,
+		maxRetries:  3.0,
 	}
 
 	callCount := 0
@@ -341,8 +360,10 @@ func TestDownload(t *testing.T) {
 	token := "faketoken"
 	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
 	downloader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: 1.0,
+		maxRetries:  3.0,
 	}
 	called := false
 
@@ -380,8 +401,10 @@ func TestDownloadZip(t *testing.T) {
 
 	u, _ := url.Parse("http://fakestore.com/v1/caches/events/1234/" + testfilepath)
 	downloader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: 1.0,
+		maxRetries:  3.0,
 	}
 	called := false
 
@@ -419,12 +442,13 @@ func TestDownloadZip(t *testing.T) {
 }
 
 func TestDownloadRetry(t *testing.T) {
-	retryScaler = .01
 	token := "faketoken"
 	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
 	downloader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: .01,
+		maxRetries:  3.0,
 	}
 
 	callCount := 0
@@ -446,8 +470,10 @@ func TestDownloadWriteBack(t *testing.T) {
 	testfilepath := "/tmp/test-data/node_modules/schema/file"
 	u, _ := url.Parse("http://fakestore.com/v1/caches/events/1234/" + testfilepath)
 	downloader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: 1.0,
+		maxRetries:  3.0,
 	}
 	called := false
 
@@ -488,8 +514,10 @@ func TestDownloadWriteBackSpecialFile(t *testing.T) {
 	testfilename := "!-_.*'()&@:,.$= ?; space"
 	u, _ := url.Parse("http://fakestore.com/v1/caches/events/1234/" + testfolder + "%21-_.%2A%27%28%29%26%40%3A%2C.%24%3D%2B%3F%3B+space")
 	downloader := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: 1.0,
+		maxRetries:  3.0,
 	}
 	called := false
 
@@ -529,8 +557,10 @@ func TestRemove(t *testing.T) {
 	token := "faketoken"
 	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
 	removeRes := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: 1.0,
+		maxRetries:  3.0,
 	}
 	called := false
 
@@ -555,12 +585,13 @@ func TestRemove(t *testing.T) {
 }
 
 func TestRemoveRetry(t *testing.T) {
-	retryScaler = .01
 	token := "faketoken"
 	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
 	removeRes := &sdStore{
-		token,
-		&http.Client{Timeout: 10 * time.Second},
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		retryScaler: .01,
+		maxRetries:  3.0,
 	}
 
 	callCount := 0
@@ -601,4 +632,79 @@ func TestZipAndUnzipWithSymlink(t *testing.T) {
 
 	os.RemoveAll("../data/test")
 	os.RemoveAll("../data/testsymlink.zip")
+}
+
+func TestBackOff(t *testing.T) {
+	client := newStore(1.5, 5)
+	cases := []struct {
+		attemptNum  int
+		backoffTime time.Duration
+	}{
+		{attemptNum: 1, backoffTime: 1 * time.Second},
+		{attemptNum: 5, backoffTime: 37 * time.Second},
+	}
+
+	for _, c := range cases {
+		bt := client.backOff(c.attemptNum)
+		assert.Equal(t, c.backoffTime, bt, fmt.Sprintf("when attempt number is %v", c.attemptNum))
+		if bt != c.backoffTime {
+			t.Errorf("Expected time is %q. But Got %q", c.backoffTime, bt)
+		}
+	}
+}
+
+func TestCheckForRetry(t *testing.T) {
+	client := newStore(1.0, 3)
+
+	cases := []struct {
+		err        error
+		statusCode int
+		doesRetry  bool
+	}{
+		{err: fmt.Errorf("awful things happen"), statusCode: 0, doesRetry: true},
+		// statut 200~
+		{statusCode: http.StatusOK, doesRetry: false},
+		{statusCode: http.StatusCreated, doesRetry: false},
+		{statusCode: http.StatusAccepted, doesRetry: false},
+		{statusCode: http.StatusNoContent, doesRetry: false},
+		// status 400~
+		{statusCode: http.StatusBadRequest, doesRetry: true},
+		{statusCode: http.StatusUnauthorized, doesRetry: true},
+		{statusCode: http.StatusForbidden, doesRetry: true},
+		{statusCode: http.StatusNotFound, doesRetry: false},
+		{statusCode: http.StatusRequestTimeout, doesRetry: true},
+		// status 500~
+		{err: nil, statusCode: http.StatusInternalServerError, doesRetry: true},
+	}
+
+	for _, c := range cases {
+		res := &http.Response{}
+		res.StatusCode = c.statusCode
+		retry := client.checkForRetry(res, c.err)
+		assert.Equal(t, c.doesRetry, retry, fmt.Sprintf("when status is %d and err is %q", c.statusCode, c.err))
+	}
+}
+
+func TestDo(t *testing.T) {
+	client := newStore(.01, 4)
+	callCount := 0
+	client.client = makeFakeHTTPClient(t, 500, "ERROR", func(r *http.Request) {
+		callCount++
+	})
+	req, _ := http.NewRequest("GET", "http://fakestore/v1/test", nil)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", client.token))
+	fmt.Println(req.URL.String())
+	_, err := client.do(req)
+	assert.NotNil(t, err, "when failed retry until max retry num, it should return err")
+	assert.Equal(t, 4, callCount, "client must retry specified number")
+
+	callCount = 0
+	client.client = makeFakeHTTPClient(t, 200, "test-content", func(r *http.Request) {
+		callCount++
+	})
+	res, err := client.do(req)
+	assert.Nil(t, err, "when got 200 should return no error")
+	b, _ := ioutil.ReadAll(res.Body)
+	assert.Equal(t, "test-content", string(b), "when 200 should return proper body")
+
 }

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -51,9 +51,9 @@ func makeFakeHTTPClient(t *testing.T, code int, body string, v func(r *http.Requ
 		w.WriteHeader(code)
 		w.Header().Set("Content-Type", "application/json")
 
-		if r.URL.String() == "http://fakestore.com/v1/caches/events/123/../data/emitterdata_md5.json" {
+		if r.URL.String() == "http://fakestore.example.com/v1/caches/events/123/../data/emitterdata_md5.json" {
 			w.Write([]byte("{\"../data/emitterdata\":\"73a256001a246e77fd1941ca007b50r2\"}"))
-		} else if r.URL.String() == "http://fakestore.com/v1/caches/events/123/../data/emitterdata2_md5.json" {
+		} else if r.URL.String() == "http://fakestore.example.com/v1/caches/events/123/../data/emitterdata2_md5.json" {
 			w.Write([]byte("{\"../data/emitterdata2\":\"b567651333fff804168aabac8284d708\"}"))
 		} else {
 			w.Write([]byte(body))
@@ -121,7 +121,7 @@ func testZipFile() *os.File {
 
 func TestUpload(t *testing.T) {
 	token := "faketoken"
-	u, _ := url.Parse("http://fakestore.com/builds/emitterdata")
+	u, _ := url.Parse("http://fakestore.example.com/builds/emitterdata")
 	uploader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -170,7 +170,7 @@ func TestUploadZipWithChange(t *testing.T) {
 	token := "faketoken"
 	file := "../data/emitterdata"
 	zipfile := file + ".zip"
-	u, _ := url.Parse("http://fakestore.com/v1/caches/events/123/" + file)
+	u, _ := url.Parse("http://fakestore.example.com/v1/caches/events/123/" + file)
 	uploader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -272,7 +272,7 @@ func TestUploadZipWithChange(t *testing.T) {
 func TestUploadZipNoChange(t *testing.T) {
 	token := "faketoken"
 	file := "../data/emitterdata2"
-	u, _ := url.Parse("http://fakestore.com/v1/caches/events/123/" + file)
+	u, _ := url.Parse("http://fakestore.example.com/v1/caches/events/123/" + file)
 	uploader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -309,7 +309,7 @@ func TestUploadZipNoChange(t *testing.T) {
 
 func TestUploadRetry(t *testing.T) {
 	token := "faketoken"
-	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
+	u, _ := url.Parse("http://fakestore.example.com/builds/1234-test")
 	uploader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -333,7 +333,7 @@ func TestUploadRetry(t *testing.T) {
 
 func TestUploadZipRetry(t *testing.T) {
 	token := "faketoken"
-	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
+	u, _ := url.Parse("http://fakestore.example.com/builds/1234-test")
 	uploader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -358,7 +358,7 @@ func TestUploadZipRetry(t *testing.T) {
 
 func TestDownload(t *testing.T) {
 	token := "faketoken"
-	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
+	u, _ := url.Parse("http://fakestore.example.com/builds/1234-test")
 	downloader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -399,7 +399,7 @@ func TestDownloadZip(t *testing.T) {
 	testfilepath := abspath + "/../data/test.zip"
 	testfilepath = url.QueryEscape(testfilepath)
 
-	u, _ := url.Parse("http://fakestore.com/v1/caches/events/1234/" + testfilepath)
+	u, _ := url.Parse("http://fakestore.example.com/v1/caches/events/1234/" + testfilepath)
 	downloader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -443,7 +443,7 @@ func TestDownloadZip(t *testing.T) {
 
 func TestDownloadRetry(t *testing.T) {
 	token := "faketoken"
-	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
+	u, _ := url.Parse("http://fakestore.example.com/builds/1234-test")
 	downloader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -468,7 +468,7 @@ func TestDownloadRetry(t *testing.T) {
 func TestDownloadWriteBack(t *testing.T) {
 	token := "faketoken"
 	testfilepath := "/tmp/test-data/node_modules/schema/file"
-	u, _ := url.Parse("http://fakestore.com/v1/caches/events/1234/" + testfilepath)
+	u, _ := url.Parse("http://fakestore.example.com/v1/caches/events/1234/" + testfilepath)
 	downloader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -512,7 +512,7 @@ func TestDownloadWriteBackSpecialFile(t *testing.T) {
 	token := "faketoken"
 	testfolder := "/tmp/test-data/node_modules/schema/"
 	testfilename := "!-_.*'()&@:,.$= ?; space"
-	u, _ := url.Parse("http://fakestore.com/v1/caches/events/1234/" + testfolder + "%21-_.%2A%27%28%29%26%40%3A%2C.%24%3D%2B%3F%3B+space")
+	u, _ := url.Parse("http://fakestore.example.com/v1/caches/events/1234/" + testfolder + "%21-_.%2A%27%28%29%26%40%3A%2C.%24%3D%2B%3F%3B+space")
 	downloader := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -555,7 +555,7 @@ func TestDownloadWriteBackSpecialFile(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	token := "faketoken"
-	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
+	u, _ := url.Parse("http://fakestore.example.com/builds/1234-test")
 	removeRes := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -586,7 +586,7 @@ func TestRemove(t *testing.T) {
 
 func TestRemoveRetry(t *testing.T) {
 	token := "faketoken"
-	u, _ := url.Parse("http://fakestore.com/builds/1234-test")
+	u, _ := url.Parse("http://fakestore.example.com/builds/1234-test")
 	removeRes := &sdStore{
 		token:       token,
 		client:      &http.Client{Timeout: 10 * time.Second},
@@ -690,7 +690,7 @@ func TestCheckForRetry(t *testing.T) {
 
 func TestDo(t *testing.T) {
 	client := newStore(.01, 4)
-	req, _ := http.NewRequest("GET", "http://fakestore/v2/test", nil)
+	req, _ := http.NewRequest("GET", "http://fakestore.example.com/v1/test", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", client.token))
 
 	cases := []struct {
@@ -700,9 +700,9 @@ func TestDo(t *testing.T) {
 		err         error
 		responseNil bool
 	}{
-		{statusCode: 500, body: "ERROR", callCount: 4, err: fmt.Errorf("getting from http://fakestore/v2/test after 4 retries"), responseNil: true},
+		{statusCode: 500, body: "ERROR", callCount: 4, err: fmt.Errorf("getting from http://fakestore.example.com/v1/test after 4 retries"), responseNil: true},
 		{statusCode: 200, body: "test-contents", callCount: 1},
-		{statusCode: 404, body: "Not Found", callCount: 1, err: fmt.Errorf("got 404 Not Found from http://fakestore/v2/test. stop retring")},
+		{statusCode: 404, body: "Not Found", callCount: 1, err: fmt.Errorf("got 404 Not Found from http://fakestore.example.com/v1/test. stop retring")},
 	}
 
 	for _, c := range cases {

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -672,7 +672,7 @@ func TestCheckForRetry(t *testing.T) {
 		{statusCode: http.StatusBadRequest, doesRetry: true},
 		{statusCode: http.StatusUnauthorized, doesRetry: true},
 		{statusCode: http.StatusForbidden, doesRetry: true},
-		{statusCode: http.StatusNotFound, doesRetry: false, retryErr: fmt.Errorf("got 404 Not Found. stop retring")},
+		{statusCode: http.StatusNotFound, doesRetry: false, retryErr: fmt.Errorf("got code 404. stop retring")},
 		{statusCode: http.StatusRequestTimeout, doesRetry: true},
 		// status 500~
 		{err: nil, statusCode: http.StatusInternalServerError, doesRetry: true},
@@ -681,7 +681,7 @@ func TestCheckForRetry(t *testing.T) {
 	for _, c := range cases {
 		res := &http.Response{}
 		res.StatusCode = c.statusCode
-		res.Status = "404 Not Found"
+		res.Status = fmt.Sprintf("code %d", res.StatusCode)
 		retry, err := client.checkForRetry(res, c.err)
 		assert.Equal(t, c.doesRetry, retry, fmt.Sprintf("when status is %d and err is %q", c.statusCode, c.err))
 		assert.Equal(t, c.retryErr, err, "when status is %d and err is %q", c.statusCode, c.err)

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -672,7 +672,7 @@ func TestCheckForRetry(t *testing.T) {
 		{statusCode: http.StatusBadRequest, doesRetry: true},
 		{statusCode: http.StatusUnauthorized, doesRetry: true},
 		{statusCode: http.StatusForbidden, doesRetry: true},
-		{statusCode: http.StatusNotFound, doesRetry: false, retryErr: fmt.Errorf("got code 404. stop retring")},
+		{statusCode: http.StatusNotFound, doesRetry: false, retryErr: fmt.Errorf("got code 404. stop retrying")},
 		{statusCode: http.StatusRequestTimeout, doesRetry: true},
 		// status 500~
 		{err: nil, statusCode: http.StatusInternalServerError, doesRetry: true},
@@ -702,7 +702,7 @@ func TestDo(t *testing.T) {
 	}{
 		{statusCode: 500, body: "ERROR", callCount: 4, err: fmt.Errorf("getting from http://fakestore.example.com/v1/test after 4 retries"), responseNil: true},
 		{statusCode: 200, body: "test-contents", callCount: 1},
-		{statusCode: 404, body: "Not Found", callCount: 1, err: fmt.Errorf("got 404 Not Found from http://fakestore.example.com/v1/test. stop retring")},
+		{statusCode: 404, body: "Not Found", callCount: 1, err: fmt.Errorf("got 404 Not Found from http://fakestore.example.com/v1/test. stop retrying")},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Context
Now store-cli try to retry even get status 404. If store does not have contents, store-cli do not need to retry.

Also now store-cli retry without http status problem. Thus I fix store-cli to check only request err and status code for retry.

## Objective
- Download function only retry when request err and status code has problem.
- Download function does not retry when store return 404

I will fix Remove and Upload function next PR.

## References

related issue https://github.com/screwdriver-cd/screwdriver/issues/1396