### PR TITLE
fix: return non 20X status code to user

### DIFF
--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -226,6 +226,7 @@ func handleResponse(res *http.Response) ([]byte, error) {
 	if res.StatusCode/100 != 2 {
 		return nil, fmt.Errorf("HTTP %d returned: %s", res.StatusCode, body)
 	}
+
 	return body, nil
 }
 
@@ -312,29 +313,48 @@ func (s *sdStore) get(url *url.URL, toExtract bool) ([]byte, error) {
 }
 
 // putFile writes a file at filePath to a url with a PUT request. It streams the data from disk to save memory
+// Need to retry here so that we can re-open the file cuz httpClient closes the file after each request
 func (s *sdStore) putFile(url *url.URL, bodyType string, filePath string) error {
-	input, err := os.Open(filePath)
-	if err != nil {
-		return err
-	}
-	defer input.Close()
+	attemptNum := 0
 
-	stat, err := input.Stat()
-	if err != nil {
-		return err
-	}
-	fsize := stat.Size()
+	for {
+		attemptNum = attemptNum + 1
 
-	_, err = s.put(url, bodyType, input, fsize)
-	if err != nil {
-		return err
-	}
+		input, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		defer input.Close()
 
-	return nil
+		stat, err := input.Stat()
+		if err != nil {
+			return err
+		}
+		fsize := stat.Size()
+
+		res, err := s.put(url, bodyType, input, fsize)
+		defer res.Body.Close()
+
+		retry, err := s.checkForRetry(res, err)
+
+		if !retry {
+			if (err != nil) {
+				return err
+			}
+
+			return nil
+		}
+		log.Printf("(Try %d of %d) error received from %s %v: %v", attemptNum, s.maxRetries, "PUT", url, err)
+
+		if attemptNum == s.maxRetries {
+			return err
+		}
+		time.Sleep(s.backOff(attemptNum))
+	}
 }
 
 // PUT request to SD store
-func (s *sdStore) put(url *url.URL, bodyType string, payload io.Reader, size int64) ([]byte, error) {
+func (s *sdStore) put(url *url.URL, bodyType string, payload io.Reader, size int64) (*http.Response, error) {
 	req, err := http.NewRequest("PUT", url.String(), payload)
 	if err != nil {
 		return nil, err
@@ -344,13 +364,9 @@ func (s *sdStore) put(url *url.URL, bodyType string, payload io.Reader, size int
 	req.Header.Set("Content-Type", bodyType)
 	req.ContentLength = size
 
-	res, err := s.do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
+	res, err := s.client.Do(req)
 
-	return handleResponse(res)
+	return res, err
 }
 
 func (s *sdStore) backOff(attemptNum int) time.Duration {
@@ -362,7 +378,7 @@ func (s *sdStore) checkForRetry(res *http.Response, err error) (bool, error) {
 		log.Printf("failed to request to store: %v", err)
 		return true, err
 	}
-	if res.StatusCode == http.StatusNotFound {
+	if res.StatusCode/100 == 4 && res.StatusCode != http.StatusRequestTimeout && res.StatusCode != http.StatusTooManyRequests {
 		if res.Request != nil && res.Request.URL != nil {
 			return false, fmt.Errorf("got %s from %s. stop retrying", res.Status, res.Request.URL)
 		}
@@ -380,7 +396,9 @@ func (s *sdStore) do(req *http.Request) (*http.Response, error) {
 	attemptNum := 0
 	for {
 		attemptNum = attemptNum + 1
+
 		res, err := s.client.Do(req)
+
 		retry, err := s.checkForRetry(res, err)
 		if !retry {
 			return res, err

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -370,7 +370,7 @@ func (s *sdStore) checkForRetry(res *http.Response, err error) (bool, error) {
 	}
 
 	if res.StatusCode/100 != 2 {
-		return true, fmt.Errorf("got %s from %s.", res.Status, res.Request.URL)
+		return true, fmt.Errorf("got %s.", res.Status)
 	}
 
 	return false, nil
@@ -388,9 +388,8 @@ func (s *sdStore) do(req *http.Request) (*http.Response, error) {
 		log.Printf("(Try %d of %d) error received from %s %v: %v", attemptNum, s.maxRetries, req.Method, req.URL, err)
 
 		if attemptNum == s.maxRetries {
-			break
+			return nil, fmt.Errorf("getting error from %s after %d retries: %v", req.URL, s.maxRetries, err)
 		}
 		time.Sleep(s.backOff(attemptNum))
 	}
-	return nil, fmt.Errorf("getting from %s after %d retries", req.URL, s.maxRetries)
 }

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -370,7 +370,7 @@ func (s *sdStore) checkForRetry(res *http.Response, err error) (bool, error) {
 	}
 
 	if res.StatusCode/100 != 2 {
-		return true, nil
+		return true, fmt.Errorf("got %s from %s.", res.Status, res.Request.URL)
 	}
 
 	return false, nil

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -670,13 +670,13 @@ func TestCheckForRetry(t *testing.T) {
 		{statusCode: http.StatusAccepted, doesRetry: false},
 		{statusCode: http.StatusNoContent, doesRetry: false},
 		// status 400~
-		{statusCode: http.StatusBadRequest, doesRetry: true},
-		{statusCode: http.StatusUnauthorized, doesRetry: true},
-		{statusCode: http.StatusForbidden, doesRetry: true},
+		{statusCode: http.StatusBadRequest, doesRetry: true, retryErr: fmt.Errorf("got code 400.")},
+		{statusCode: http.StatusUnauthorized, doesRetry: true, retryErr: fmt.Errorf("got code 401.")},
+		{statusCode: http.StatusForbidden, doesRetry: true, retryErr: fmt.Errorf("got code 403.")},
 		{statusCode: http.StatusNotFound, doesRetry: false, retryErr: fmt.Errorf("got code 404. stop retrying")},
-		{statusCode: http.StatusRequestTimeout, doesRetry: true},
+		{statusCode: http.StatusRequestTimeout, doesRetry: true, retryErr: fmt.Errorf("got code 408.")},
 		// status 500~
-		{err: nil, statusCode: http.StatusInternalServerError, doesRetry: true},
+		{err: nil, statusCode: http.StatusInternalServerError, doesRetry: true, retryErr: fmt.Errorf("got code 500.")},
 	}
 
 	for _, c := range cases {
@@ -701,7 +701,7 @@ func TestDo(t *testing.T) {
 		err         error
 		responseNil bool
 	}{
-		{statusCode: 500, body: "ERROR", callCount: 4, err: fmt.Errorf("getting from http://fakestore.example.com/v1/test after 4 retries"), responseNil: true},
+		{statusCode: 500, body: "ERROR", callCount: 4, err: fmt.Errorf("getting error from http://fakestore.example.com/v1/test after 4 retries: got 500 Internal Server Error."), responseNil: true},
 		{statusCode: 200, body: "test-contents", callCount: 1},
 		{statusCode: 404, body: "Not Found", callCount: 1, err: fmt.Errorf("got 404 Not Found from http://fakestore.example.com/v1/test. stop retrying")},
 	}

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -345,7 +345,6 @@ func TestUploadZipRetry(t *testing.T) {
 	callCount := int32(0)
 	http := makeFakeHTTPClient(t, 500, "ERROR", func(r *http.Request) {
 		atomic.AddInt32(&callCount, 1)
-		os.Remove("emitterdata_md5.json")
 	})
 	uploader.client = http
 	err := uploader.Upload(u, testFile().Name(), true)
@@ -355,6 +354,7 @@ func TestUploadZipRetry(t *testing.T) {
 	if atomic.LoadInt32(&callCount) != 6 {
 		t.Errorf("Expected 6 retries, got %d", callCount)
 	}
+	os.Remove("emitterdata_md5.json")
 }
 
 func TestDownload(t *testing.T) {
@@ -670,9 +670,9 @@ func TestCheckForRetry(t *testing.T) {
 		{statusCode: http.StatusAccepted, doesRetry: false},
 		{statusCode: http.StatusNoContent, doesRetry: false},
 		// status 400~
-		{statusCode: http.StatusBadRequest, doesRetry: true, retryErr: fmt.Errorf("got code 400.")},
-		{statusCode: http.StatusUnauthorized, doesRetry: true, retryErr: fmt.Errorf("got code 401.")},
-		{statusCode: http.StatusForbidden, doesRetry: true, retryErr: fmt.Errorf("got code 403.")},
+		{statusCode: http.StatusBadRequest, doesRetry: false, retryErr: fmt.Errorf("got code 400. stop retrying")},
+		{statusCode: http.StatusUnauthorized, doesRetry: false, retryErr: fmt.Errorf("got code 401. stop retrying")},
+		{statusCode: http.StatusForbidden, doesRetry: false, retryErr: fmt.Errorf("got code 403. stop retrying")},
 		{statusCode: http.StatusNotFound, doesRetry: false, retryErr: fmt.Errorf("got code 404. stop retrying")},
 		{statusCode: http.StatusRequestTimeout, doesRetry: true, retryErr: fmt.Errorf("got code 408.")},
 		// status 500~


### PR DESCRIPTION
Currently if the statusCode is non 2XX and non 404, the err is `nil`. This is confusing and makes debugging harder. Also, there is another bug introduced by last PR. If the `put` request failed, it's not actually retrying because the first request will close the file.

check cache bookend: https://beta.cd.screwdriver.cd/pipelines/956/builds/51161

This PR will
- add err msg for non 2XX and non 404 response
- retry put request from the `putFile` function so that we can re-open the file for each retry
