### PR TITLE
fix: fix syntax so that gofmt likes it

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,6 +12,7 @@ jobs:
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - test: go test ./...
             - build: go build -a -o store-cli
+            - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
 
     deploy:
         requires: main

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -338,7 +338,7 @@ func (s *sdStore) putFile(url *url.URL, bodyType string, filePath string) error 
 		retry, err := s.checkForRetry(res, err)
 
 		if !retry {
-			if (err != nil) {
+			if err != nil {
 				return err
 			}
 


### PR DESCRIPTION
gofmt changed the line to the format it likes and leaves the repo at a dirty state. go release won't work if there is dirty file.

This PR will fix the syntax and add a test-release step in main so that we can catch it in PR.

