### PR TITLE
Stream to disk with io.Copy

### DIFF
--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -357,43 +357,6 @@ func TestUploadZipRetry(t *testing.T) {
 	os.Remove("emitterdata_md5.json")
 }
 
-func TestDownload(t *testing.T) {
-	token := "faketoken"
-	u, _ := url.Parse("http://fakestore.example.com/builds/1234-test")
-	downloader := &sdStore{
-		token:       token,
-		client:      &http.Client{Timeout: 10 * time.Second},
-		retryScaler: 1.0,
-		maxRetries:  3.0,
-	}
-	called := false
-
-	want := "test-content"
-
-	http := makeFakeHTTPClient(t, 200, want, func(r *http.Request) {
-		if r.URL.Path != u.Path {
-			t.Errorf("Wrong URL path: %s", r.URL.Path)
-		}
-
-		called = true
-
-		if r.Method != "GET" {
-			t.Errorf("Called with method %s, want GET", r.Method)
-		}
-	})
-
-	downloader.client = http
-	res, _ := downloader.Download(u, false)
-
-	if string(res) != want {
-		t.Errorf("Response is %s, want %s", string(res), want)
-	}
-
-	if !called {
-		t.Fatalf("The HTTP client was never used.")
-	}
-}
-
 func TestDownloadZip(t *testing.T) {
 	token := "faketoken"
 	abspath, _ := filepath.Abs("./")
@@ -422,7 +385,7 @@ func TestDownloadZip(t *testing.T) {
 	})
 
 	downloader.client = http
-	_, _ = downloader.Download(u, true)
+	_ = downloader.Download(u, true)
 
 	want, _ := ioutil.ReadFile("../data/emitterdata")
 	got, _ := ioutil.ReadFile(abspath + "/../data/tmp/test/emitterdata")
@@ -457,12 +420,12 @@ func TestDownloadRetry(t *testing.T) {
 		callCount++
 	})
 	downloader.client = http
-	_, err := downloader.Download(u, false)
+	err := downloader.Download(u, false)
 	if err == nil {
 		t.Error("Expected error from downloader.Download(), got nil")
 	}
 	if callCount != 3 {
-		t.Errorf("Expected 6 retries, got %d", callCount)
+		t.Errorf("Expected 3 retries, got %d", callCount)
 	}
 }
 
@@ -489,11 +452,7 @@ func TestDownloadWriteBack(t *testing.T) {
 	})
 
 	downloader.client = http
-	res, _ := downloader.Download(u, false)
-
-	if string(res) != want {
-		t.Errorf("Response is %s, want %s", string(res), want)
-	}
+	_ = downloader.Download(u, false)
 
 	filecontent, err := ioutil.ReadFile(testfilepath)
 	if err != nil {
@@ -533,11 +492,7 @@ func TestDownloadWriteBackSpecialFile(t *testing.T) {
 	})
 
 	downloader.client = http
-	res, _ := downloader.Download(u, false)
-
-	if string(res) != want {
-		t.Errorf("Response is %s, want %s", string(res), want)
-	}
+	_ = downloader.Download(u, false)
 
 	fileInfo, err := os.Stat(testfolder + testfilename)
 	filecontent, err := ioutil.ReadFile(testfolder + fileInfo.Name())
@@ -605,7 +560,7 @@ func TestRemoveRetry(t *testing.T) {
 		t.Errorf("Expected error from removeRes.Remove(), got nil")
 	}
 	if callCount != 3 {
-		t.Errorf("Expected 6 retries, got %d", callCount)
+		t.Errorf("Expected 3 retries, got %d", callCount)
 	}
 }
 

--- a/store-cli.go
+++ b/store-cli.go
@@ -128,7 +128,7 @@ func get(storeType, scope, key string) error {
 		toExtract = false
 	}
 
-	_, err = store.Download(fullURL, toExtract)
+	err = store.Download(fullURL, toExtract)
 
 	return err
 }


### PR DESCRIPTION
## Context

store-cli downloads large objects into memory, this is unnecessary and can cause users to require more memory for their jobs

## Objective

Use `io.Copy` to stream to disk.

## References

Fixes https://github.com/screwdriver-cd/store-cli/issues/33
Fixes https://github.com/screwdriver-cd/screwdriver/issues/1602

See https://golang.org/pkg/io/#Copy

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
