### PR TITLE
Log file size when upload completes or fails

### DIFF
--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -195,10 +195,10 @@ func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 	if !toCompress {
 		err := s.putFile(u, "text/plain", filePath)
 		if err != nil {
-			log.Printf("failed to upload files %v", filePath)
+			log.Printf("failed to upload files %v to store (upload size = %s)", filePath, fileSize(filePath))
 			return err
 		}
-		log.Printf("Upload to %s successful.", u.String())
+		log.Printf("Upload to %s successful (upload sze = %s).", u.String(), fileSize(filePath))
 		return nil
 	}
 
@@ -254,12 +254,26 @@ func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 	}
 	err = s.putFile(encodedURL, "text/plain", zipPath)
 	if err != nil {
-		log.Printf("failed to upload file")
+		log.Printf("failed to upload file %s to store upload size = %s)", zipPath, fileSize(zipPath))
 		return err
 	}
-	log.Printf("Upload to %s successful.", u.String())
+	log.Printf("Upload to %s successful (upload size = %s).", u.String(), fileSize(zipPath))
 
 	return nil
+}
+
+// return file size suitible for logging (ignores errors)
+func fileSize(path string) string {
+	file, err := os.Open(path)
+	if err != nil {
+		return "n/a"
+	}
+	fi, err := file.Stat()
+	if err != nil {
+		return "n/a"
+	}
+
+	return fmt.Sprintf("%d", fi.Size())
 }
 
 // token header for request

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -198,7 +198,7 @@ func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 			log.Printf("failed to upload files %v to store (upload size = %s)", filePath, fileSize(filePath))
 			return err
 		}
-		log.Printf("Upload to %s successful (upload sze = %s).", u.String(), fileSize(filePath))
+		log.Printf("Upload to %s successful (upload size = %s).", u.String(), fileSize(filePath))
 		return nil
 	}
 

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -254,7 +254,7 @@ func (s *sdStore) Upload(u *url.URL, filePath string, toCompress bool) error {
 	}
 	err = s.putFile(encodedURL, "text/plain", zipPath)
 	if err != nil {
-		log.Printf("failed to upload file %s to store upload size = %s)", zipPath, fileSize(zipPath))
+		log.Printf("failed to upload file %s to store (upload size = %s)", zipPath, fileSize(zipPath))
 		return err
 	}
 	log.Printf("Upload to %s successful (upload size = %s).", u.String(), fileSize(zipPath))


### PR DESCRIPTION
## Context

It's helpful to know the file size to debug issues like "ERROR: got 413 Request Entity Too Large".

## Objective

This change just updates the the existing log message when an upload passes or fails to include the size.

## References

N/A
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
