### PR TITLE
fix: do not skip PR event cache

### DIFF
--- a/store-cli.go
+++ b/store-cli.go
@@ -48,10 +48,9 @@ func skipCache(storeType, scope, action string) bool {
 	}
 
 	// For PR jobs,
-	// skip event cache to save time, since PR event only consists of 1 job
 	// skip pipeline scoped unless it's trying to get
 	// skip job scoped unless it's trying to get
-	if scope == "event" || (action != "get" && (scope == "pipeline" || scope == "job")) {
+	if action != "get" && (scope == "pipeline" || scope == "job") {
 		log.Printf("Skipping %s %s-scoped cache for Pull Request", action, scope)
 		return true
 	}

--- a/store-cli_test.go
+++ b/store-cli_test.go
@@ -29,8 +29,6 @@ func TestSkipCache(t *testing.T) {
 		{"cache", "pipeline", "set", "123", true},
 		{"cache", "pipeline", "remove", "123", true},
 		{"cache", "event", "get", "", false},
-		{"cache", "event", "get", "123", true},
-		{"cache", "event", "set", "123", true},
 		{"cache", "job", "get", "", false},
 		{"cache", "job", "set", "123", true},
 		{"artifact", "event", "get", "", false},


### PR DESCRIPTION
Previously, PR event only has 1 job so we skip it to save time. 
Now PR can be chained, so we no longer want to skip. 