### PR TITLE
Restore timestamps when restoring caches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/screwdriver-cd/store-cli
+
+go 1.12
+
+require (
+	github.com/stretchr/testify v1.3.0
+	github.com/urfave/cli v1.21.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/urfave/cli v1.21.0 h1:wYSSj06510qPIzGSua9ZqsncMmWE3Zr55KBERygyrxE=
+github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,13 +1,12 @@
 shared:
     image: golang
     environment:
-        GOPATH: /sd/workspace
+        GO111MODULE: on
 
 jobs:
     main:
         requires: [~commit, ~pr]
         steps:
-            - get: go get -t ./...
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - test: go test ./...
@@ -18,7 +17,6 @@ jobs:
         requires: main
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
-            - get: go get -t ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - tag: ./ci/git-tag.sh
             - release: |

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -120,6 +120,25 @@ func testZipFile() *os.File {
 	return f
 }
 
+func checkModTime(t *testing.T, path string, expectedTime string) {
+	const format = "2006-01-02 15:04:05 -0700"
+	expected, err := time.Parse(format, expectedTime)
+	if err != nil {
+		panic(err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		panic(err)
+	}
+
+	got := fi.ModTime()
+
+	if !got.Equal(expected) {
+		t.Errorf("invalid modtime for %s: got %v, expected %v", path, got, expected)
+	}
+}
+
 func TestUpload(t *testing.T) {
 	token := "faketoken"
 	u, _ := url.Parse("http://fakestore.example.com/builds/emitterdata")
@@ -399,6 +418,9 @@ func TestDownloadZip(t *testing.T) {
 	if string(got) != string(want) {
 		t.Errorf("Response is %s, want %s", got, want)
 	}
+
+	checkModTime(t, abspath+"/../data/tmp/test/", "2018-10-04 20:38:48.000000000 +0000")
+	checkModTime(t, abspath+"/../data/tmp/test/emitterdata", "2018-10-04 20:38:48.000000000 +0000")
 
 	if !called {
 		t.Fatalf("The HTTP client was never used.")

--- a/sdstore/ziphelper.go
+++ b/sdstore/ziphelper.go
@@ -4,10 +4,12 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 var compressedFormats = map[string]struct{}{
@@ -160,6 +162,10 @@ func Unzip(src string, dest string) ([]string, error) {
 
 			// Make Folder
 			os.MkdirAll(fpath, os.ModePerm)
+
+			if err = os.Chtimes(fpath, time.Now(), f.Modified); err != nil {
+				log.Print("failed to update directory timestamps:", err)
+			}
 		} else if (f.FileInfo().Mode() & os.ModeSymlink) != 0 {
 			buffer := make([]byte, f.FileInfo().Size())
 			size, err := rc.Read(buffer)
@@ -194,6 +200,9 @@ func Unzip(src string, dest string) ([]string, error) {
 				return filenames, err
 			}
 
+			if err = os.Chtimes(fpath, time.Now(), f.Modified); err != nil {
+				log.Print("failed to update file timestamps:", err)
+			}
 		}
 	}
 	return filenames, nil


### PR DESCRIPTION
## Context

Over time, restoring and saving the same cache directory during a build can lead to a build up of old (and unneeded) data. This is especially true if the cached directory is the cache for a package manager (e.g., maven, npm, pip, go) or compiler (e.g., go, ccache).

Eventually, this build up of extra data causes the cache to exceed the maximum size of the store, which requires manually deleting the cache. In the time leading up to that point, the extra data results in slower downloads and increased storage requirements and (re)store times.

## Objective

This PR adds a signal builds can use to determine what to delete; a simple example is to delete based only on modified time:

```
find "$CACHE_DIR" -mtime +10 -delete
```

This PR also adds a `go.mod` and switches the build to use go modules.

## References

(none)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
