### PR TITLE
fix: enable versioning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,9 @@ builds:
       - darwin
     goarch:
       - amd64
-
+    ldflags:
+      - -s -w
+        -X github.com/screwdriver-cd/store-cli/main.VERSION={{.Version}}
 archive:
   format: binary
   name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"

--- a/store-cli.go
+++ b/store-cli.go
@@ -199,11 +199,12 @@ func main() {
 	defer finalRecover()
 
 	app := cli.NewApp()
-	app.Name = "store"
+	app.Name = "store-cli"
 	app.Usage = "CLI to communicate with Screwdriver Store"
 	app.UsageText = "[options]"
 	app.Copyright = "(c) 2018 Yahoo Inc."
 	app.Usage = "get, set or remove items in the Screwdriver store"
+	app.Version = VERSION
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The built cli does not have appropriate version when use `-v` flag.

```
$ docker run --rm -it -v `pwd`:/app -w /app screwdrivercd/launcher:v6.0.15 '/opt/sd/store-cli -v'
store version 0.0.0
```

I'd like to discriminate the version of store-cli in launcher image accurately without relying on the release date.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
store-cli has ability to show correct version.

I test like below with this source.
```
$ go build -a -o store-cli -ldflags "-X main.VERSION=1.2.3"; ./store-cli -v
store-cli version 1.2.3
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
