### PR TITLE
fix: versioning do not work

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ builds:
       - amd64
     ldflags:
       - -s -w
-        -X github.com/screwdriver-cd/store-cli/main.VERSION={{.Version}}
+        -X main.VERSION={{.Version}}
 archive:
   format: binary
   name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Store cli does not show version.
```
$ ./store-cli_darwin_amd64 -v
store-cli version
```

This is because [the specifying of ldflag](https://github.com/screwdriver-cd/store-cli/blob/c85dc2ae84f90bade26488b0ac07dd6c59cffae9/.goreleaser.yml#L10) is wrong.

It seems that ldflag works with the format like `github,com/screwdriver-cd/...` for package other than `main`.

I could not find official document about that, but I confirm like below.
```
yoshwata ex 0 at MBP15UAW-B001 in ~/git/githubcom/sonic-screwdriver-cd/store-cli on fix-versioning
$ git tag v0.0.102

yoshwata ex 0 at MBP15UAW-B001 in ~/git/githubcom/sonic-screwdriver-cd/store-cli on fix-versioning
$ goreleaser --skip-publish --rm-dist;dist/store-cli_darwin_amd64/store-cli -v

   • releasing using goreleaser 0.117.0...
   • loading config file       file=.goreleaser.yml
   • RUNNING BEFORE HOOKS
   • LOADING ENVIRONMENT VARIABLES
      • pipe skipped              error=publishing is disabled
   • GETTING AND VALIDATING GIT STATE
      • releasing v0.0.102, commit b9e8b4282440333320a894a67c1e97b46df7b5b8
   • PARSING TAG
   • SETTING DEFAULTS
      • LOADING ENVIRONMENT VARIABLES
      • SNAPSHOTING
      • GITHUB/GITLAB/GITEA RELEASES
      • PROJECT NAME
      • BUILDING BINARIES
      • ARCHIVES
            • DEPRECATED: `archive` should not be used anymore, check https://goreleaser.com/deprecations#archive for more info.
      • LINUX PACKAGES WITH NFPM
      • SNAPCRAFT PACKAGES
      • CALCULATING CHECKSUMS
      • SIGNING ARTIFACTS
      • DOCKER IMAGES
      • ARTIFACTORY
      • S3
      • BLOB
      • HOMEBREW TAP FORMULA
         • optimistically guessing `brew[0].installs`, double check
      • SCOOP MANIFEST
   • SNAPSHOTING
      • pipe skipped              error=not a snapshot
   • CHECKING ./DIST
      • --rm-dist is set, cleaning it up
   • WRITING EFFECTIVE CONFIG FILE
      • writing                   config=dist/config.yaml
   • GENERATING CHANGELOG
      • writing                   changelog=dist/CHANGELOG.md
   • BUILDING BINARIES
      • building                  binary=dist/store-cli_darwin_amd64/store-cli
      • building                  binary=dist/store-cli_linux_amd64/store-cli
   • ARCHIVES
      • skip archiving            binary=store-cli
      • skip archiving            binary=store-cli
   • LINUX PACKAGES WITH NFPM
      • pipe skipped              error=no output formats configured
   • SNAPCRAFT PACKAGES
      • pipe skipped              error=no summary nor description were provided
   • CALCULATING CHECKSUMS
      • checksumming              file=store-cli_linux_amd64
      • checksumming              file=store-cli_darwin_amd64
   • SIGNING ARTIFACTS
      • pipe skipped              error=artifact signing is disabled
   • DOCKER IMAGES
      • pipe skipped              error=docker section is not configured
   • PUBLISHING
      • pipe skipped              error=publishing is disabled
   • release succeeded after 2.22s

store-cli version 0.0.102
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix version output.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
