### PR TITLE
fix(1830): gofmt exit on error

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -8,7 +8,7 @@ jobs:
         requires: [~commit, ~pr]
         steps:
             - vet: go vet ./...
-            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - gofmt: "find . -name '*.go' | xargs gofmt -d"
             - test: go test ./...
             - build: go build -a -o store-cli
             - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
@@ -17,7 +17,7 @@ jobs:
         requires: main
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
-            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - gofmt: "find . -name '*.go' | xargs gofmt -d"
             - tag: ./ci/git-tag.sh
             - release: |
                 curl -sL https://git.io/goreleaser | bash

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -23,7 +23,7 @@ func Cache2Disk(command, cacheScope, srcDir string) error {
 	command = strings.ToLower(strings.TrimSpace(command))
 	cacheScope = strings.ToLower(strings.TrimSpace(cacheScope))
 
-	if command != "set" && command != "get" && command !="remove" {
+	if command != "set" && command != "get" && command != "remove" {
 		return fmt.Errorf("error: %v, command: %v is not expected", err, command)
 	}
 
@@ -87,6 +87,6 @@ func Cache2Disk(command, cacheScope, srcDir string) error {
 		return err
 	}
 
-	fmt.Println ("Cache complete ...")
+	fmt.Println("Cache complete ...")
 	return nil
 }

--- a/sdstore/cache2disk_test.go
+++ b/sdstore/cache2disk_test.go
@@ -29,7 +29,7 @@ func Init(cleanup bool) error {
 		_ = os.MkdirAll(cacheDir, 0777)
 		cacheDir, _ = filepath.Abs(os.Getenv("SD_EVENT_CACHE_DIR"))
 		_ = os.MkdirAll(cacheDir, 0777)
-		cacheDir, _ =  filepath.Abs(os.Getenv("SD_JOB_CACHE_DIR"))
+		cacheDir, _ = filepath.Abs(os.Getenv("SD_JOB_CACHE_DIR"))
 		_ = os.MkdirAll(cacheDir, 0777)
 		cacheDir = filepath.Join(home, "/tmp/storeclicache/server")
 		_ = os.MkdirAll(cacheDir, 0777)
@@ -151,7 +151,7 @@ func TestCache2DiskRemoveCache(t *testing.T) {
 
 	assert.Assert(t, Cache2Disk("remove", "pipeline", "../data/cache/local") == nil)
 
-	_, err := os.Stat(filepath.Join(cache,local))
+	_, err := os.Stat(filepath.Join(cache, local))
 	assert.ErrorContains(t, err, "no such file or directory")
 }
 
@@ -161,7 +161,7 @@ func TestCache2DiskForPipelineWithTilde(t *testing.T) {
 	_ = os.Setenv("SD_PIPELINE_CACHE_DIR", "~/tmp/storeclicache/server")
 	local := "~/tmp/storeclicache/local"
 	home, _ := os.UserHomeDir()
-	localDir := filepath.Join(home, "/tmp/storeclicache","local")
+	localDir := filepath.Join(home, "/tmp/storeclicache", "local")
 	cache := filepath.Join(home, "/tmp/storeclicache", "server")
 
 	_ = os.MkdirAll(localDir, 0777)


### PR DESCRIPTION
## Context

gofmt doesnt exit on error

## Objective

gofmt exit on error

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
