### PR TITLE
fix(1830): update cache strategy environment variable

### DIFF
--- a/store-cli.go
+++ b/store-cli.go
@@ -15,7 +15,7 @@ import (
 
 // VERSION gets set by the build script via the LDFLAGS
 var VERSION string
-var CacheStrategy string = strings.ToLower(os.Getenv("CACHE_STRATEGY"))
+var CacheStrategy string = strings.ToLower(os.Getenv("SD_CACHE_STRATEGY"))
 
 // successExit exits process with 0
 func successExit() {


### PR DESCRIPTION
## Context

referring incorrect CACHE_STRATEGY environment variable

## Objective

update environment variable from CACHE_STRATEGY to SD_CACHE_STRATEGY. refer: https://github.com/screwdriver-cd/launcher/blob/master/launch.go#L433

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
