### PR TITLE
fix(1830): error if src path not found only on set

### DIFF
--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -69,9 +69,12 @@ func Cache2Disk(command, cacheScope, srcDir string) error {
 		dest = srcDir
 	}
 
-	if command == "set" {
-		if _, err = os.Stat(src); err != nil {
-			return fmt.Errorf("error: %v, source path not found", err)
+	if _, err = os.Stat(src); err != nil {
+		if command == "set" {
+			return fmt.Errorf("error: %v, source path not found for command %v", err, command)
+		} else {
+			fmt.Printf("skipping source path not found error for command %v, error: %v", command, err)
+			return nil
 		}
 	}
 

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -69,8 +69,10 @@ func Cache2Disk(command, cacheScope, srcDir string) error {
 		dest = srcDir
 	}
 
-	if _, err = os.Stat(src); err != nil {
-		return fmt.Errorf("error: %v, source path not found", err)
+	if command == "set" {
+		if _, err = os.Stat(src); err != nil {
+			return fmt.Errorf("error: %v, source path not found", err)
+		}
 	}
 
 	if command != "get" {

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -77,8 +77,9 @@ func Cache2Disk(command, cacheScope, srcDir string) error {
 
 	if command != "get" {
 		if err = os.RemoveAll(dest); err != nil {
-			return fmt.Errorf("error: %v, failed to clean out the destination directory: %v", err, dest)
+			fmt.Printf("error: %v, failed to clean out the destination directory: %v", err, dest)
 		}
+
 		if command == "remove" {
 			fmt.Printf("command: %v, cache directories %v removed \n", command, dest)
 			return nil

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -72,7 +72,9 @@ func Cache2Disk(command, cacheScope, srcDir string) error {
 	if _, err = os.Stat(src); err != nil {
 		if command == "set" {
 			return fmt.Errorf("error: %v, source path not found for command %v", err, command)
-		} else {
+		}
+
+		if command == "get" {
 			fmt.Printf("skipping source path not found error for command %v, error: %v", command, err)
 			return nil
 		}

--- a/sdstore/cache2disk_test.go
+++ b/sdstore/cache2disk_test.go
@@ -64,13 +64,13 @@ func TestCache2DiskInvalidSrcPathSet(t *testing.T) {
 // test to validate invalid src and cache path for get
 func TestCache2DiskInvalidSrcPathGet(t *testing.T) {
 	err := Cache2Disk("get", "pipeline", "../nodirectory/cache/local")
-	assert.ErrorContains(t, err, "no such file or directory")
+	assert.Assert(t, err == nil)
 }
 
 // test to validate invalid src and cache path for remove
 func TestCache2DiskInvalidSrcPathRemove(t *testing.T) {
 	err := Cache2Disk("remove", "pipeline", "../nodirectory/cache/local")
-	assert.ErrorContains(t, err, "no such file or directory")
+	assert.Assert(t, err == nil)
 }
 
 // test to copy cache files from local build dir to shared storage


### PR DESCRIPTION
## Context

get cache erroring when the cache path is not available

## Objective

os.stat check should be done only as part of set cache

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
