### PR TITLE
Make the stack output a string rather than array of bytes.

### DIFF
--- a/store-cli.go
+++ b/store-cli.go
@@ -39,7 +39,7 @@ func failureExit(err error) {
 func finalRecover() {
 	if p := recover(); p != nil {
 		fmt.Fprintln(os.Stderr, "ERROR: Something terrible has happened. Please file a ticket with this info:")
-		fmt.Fprintf(os.Stderr, "ERROR: %v\n%v\n", p, debug.Stack())
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n%s\n", p, string(debug.Stack()))
 		failureExit(nil)
 	}
 	successExit()


### PR DESCRIPTION
## Context

Stack dumps are hard to read currently:

```
00:00:30 ERROR: Something terrible has happened. Please file a ticket with this info:
00:00:30 ERROR: runtime error: invalid memory address or nil pointer dereference
00:00:30 [103 111 114 111 117 116 105 110 101 32 49 32 91 114 117 110 110 105 110 103 93 58 10 114 117 110 116 105 109 101 47 100 101 98 117 103 46 83 116 97 99 107 40 48 120 56 55 99 48 99 48 44 32 48 120 99 48 48 48 48 57 54 48 49 48 44 32 48 120 99 48 48 48 48 98 102 53 98 48 41 10 9 47 117 115 114 47 108 111 99 97 108 47 103 111 47 115 114 99 47 114 117 110 116 105 109 101 47 100 101 98 117 103 47 115 116 97 99 107 46 103 111 58 50 52 32 43 48 120 57 100 10 109 97 105 110 46 102 105 110 97 108 82 101 99 111 118 101 114 40 41 10 9 47 115 100 47 119 111 114 107 115 112 97 99 101 47 115 114 99 47 103 105 116 104 117 98 46 99 111 109 47 115 99 114 101 119 100 114 105 118 101 114 45 99 100 47 115 116 111 114 101 45 99 108 105 47 115 116 111 114 101 45 99 108 105 46 103 111 58 51 55 32 43 48 120 100 52 10 112 97 110 105 99 40 48 120 55 57 99 48 56 48 44 32 48 120 98 48 49 54 54 48 41 10 9 47 117 115 114 47 108 111 99 97 108 47 103 111 47 115 114 99 47 114 117 110 116 105 109 101 47 112 97 110 105 99 46 103 111 58 53 50 50 32 43 48 120 49 98 53 10 103 105 116 104 117 98 46 99 111 109 47 115 99 114 101 119 100 114 105 118 101 114 45 99 100 47 115 116 111 114 101 45 99 108 105 47 115 100 115 116 111 114 101 46 40 42 115 100 83 116 111 114 101 41 46 112 117 116 70 105 108 101 40 48 120 99 48 48 48 48 55 101 102 99 48 44 32 48 120 99 48 48 48 48 102 101 48 48 48 44 32 48 120 55 102 100 57 100 55 44 32 48 120 97 44 32 48 120 55 102 102 99 53 50 100 100 48 102 100 53 44 32 48 120 102 44 32 48 120 48 44 32 48 120 48 41 10 9 47 115 100 47 119 111 114 107 115 112 97 99 101 47 115 114 99 47 103 105 116 104 117 98 46 99 111 109 47 115 99 114 101 119 100 114 105 118 101 114 45 99 100 47 115 116 111 114 101 45 99 108 105 47 115 100 115 116 111 114 101 47 115 100 115 116 111 114 101 46 103 111 58 51 53 55 32 43 48 120 49 55 56 10 103 105 116 104 117 98 46 99 111 109 47 115 99 114 101 119 100 114 105 118 101 114 45 99 100 47 115 116 111 114 101 45 99 108 105 47 115 100 115 116 111 114 101 46 40 42 115 100 83 116 111 114 101 41 46 85 112 108 111 97 100 40 48 120 99 48 48 48 48 55 101 102 99 48 44 32 48 120 99 48 48 48 48 102 101 48 48 48 44 32 48 120 55 102 102 99 53 50 100 100 48 102 100 53 44 32 48 120 102 44 32 48 120 55 102 102 99 53 50 100 100 48 102 48 48 44 32 48 120 48 44 32 48 120 48 41 10 9 47 115 100 47 119 111 114 107 115 112 97 99 101 47 115 114 99 47 103 105 116 104 117 98 46 99 111 109 47 115 99 114 101 119 100 114 105 118 101 114 45 99 100 47 115 116 111 114 101 45 99 108 105 47 115 100 115 116 111 114 101 47 115 100 115 116 111 114 101 46 103 111 58 49 57 54 32 43 48 120 99 52 49 10 109 97 105 110 46 115 101 116 40 48 120 55 102 102 99 53 50 100 100 48 102 101 99 44 32 48 120 56 44 32 48 120 48 44 32 48 120 48 44 32 48 120 55 102 102 99 53 50 100 100 48 102 100 53 44 32 48 120 102 44 32 48 120 48 44 32 48 120 48 41 10 9 47 115 100 47 119 111 114 107 115 112 97 99 101 47 115 114 99 47 103 105 116 104 117 98 46 99 111 109 47 115 99 114 101 119 100 114 105 118 101 114 45 99 100 47 115 116 111 114 101 45 99 108 105 47 115 116 111 114 101 45 99 108 105 46 103 111 58 49 53 53 32 43 48 120 49 102 54 10 109 97 105 110 46 109 97 105 110 46 102 117 110 99 50 40 48 120 99 48 48 48 48 100 99 53 56 48 44 32 48 120 48 44 32 48 120 99 48 48 48 48 57 97 53 54 48 41 10 9 47 115 100 47 119 111 114 107 115 112 97 99 101 47 115 114 99 47 103 105 116 104 117 98 46 99 111 109 47 115 99 114 101 119 100 114 105 118 101 114 45 99 100 47 115 116 111 114 101 45 99 108 105 47 115 116 111 114 101 45 99 108 105 46 103 111 58 50 53 51 32 43 48 120 101 102 10 103 105 116 104 117 98 46 99 111 109 47 117 114 102 97 118 101 47 99 108 105 46 72 97 110 100 108 101 65 99 116 105 111 110 40 48 120 55 56 54 97 54 48 44 32 48 120 56 49 52 49 54 56 44 32 48 120 99 48 48 48 48 100 99 53 56 48 44 32 48 120 99 48 48 48 48 100 99 53 56 48 44 32 48 120 48 41 10 9 47 103 111 47 112 107 103 47 109 111 100 47 103 105 116 104 117 98 46 99 111 109 47 117 114 102 97 118 101 47 99 108 105 64 118 49 46 50 49 46 48 47 97 112 112 46 103 111 58 53 49 52 32 43 48 120 98 101 10 103 105 116 104 117 98 46 99 111 109 47 117 114 102 97 118 101 47 99 108 105 46 67 111 109 109 97 110 100 46 82 117 110 40 48 120 55 102 98 102 57 51 44 32 48 120 51 44 32 48 120 48 44 32 48 120 48 44 32 48 120 48 44 32 48 120 48 44 32 48 120 48 44 32 48 120 56 48 51 56 50 57 44 32 48 120 49 98 44 32 48 120 48 44 32 46 46 46 41 10 9 47 103 111 47 112 107 103 47 109 111 100 47 103 105 116 104 117 98 46 99 111 109 47 117 114 102 97 118 101 47 99 108 105 64 118 49 46 50 49 46 48 47 99 111 109 109 97 110 100 46 103 111 58 49 55 49 32 43 48 120 52 100 50 10 103 105 116 104 117 98 46 99 111 109 47 117 114 102 97 118 101 47 99 108 105 46 40 42 65 112 112 41 46 82 117 110 40 48 120 99 48 48 48 48 102 99 48 48 48 44 32 48 120 99 48 48 48 48 57 97 48 52 48 44 32 48 120 52 44 32 48 120 52 44 32 48 120 48 44 32 48 120 48 41 10 9 47 103 111 47 112 107 103 47 109 111 100 47 103 105 116 104 117 98 46 99 111 109 47 117 [line truncated after 5000 characters]
```

But with perl you can adjust to show that it would be more useful as a string.

```
[scr@C02VD2N0HTDD]$ perl -p -e 's/(\d+)\s+/chr($1) /eg' foo.txt
goroutine 1 [running]:
runtime/debug.Stack(0x87c0c0, 0xc000096010, 0xc0000bf5b0)
	/usr/local/go/src/runtime/debug/stack.go:24 +0x9d
main.finalRecover()
	/sd/workspace/src/github.com/screwdriver-cd/store-cli/store-cli.go:37 +0xd4
panic(0x79c080, 0xb01660)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/screwdriver-cd/store-cli/sdstore.(*sdStore).putFile(0xc00007efc0, 0xc0000fe000, 0x7fd9d7, 0xa, 0x7ffc52dd0fd5, 0xf, 0x0, 0x0)
	/sd/workspace/src/github.com/screwdriver-cd/store-cli/sdstore/sdstore.go:357 +0x178
github.com/screwdriver-cd/store-cli/sdstore.(*sdStore).Upload(0xc00007efc0, 0xc0000fe000, 0x7ffc52dd0fd5, 0xf, 0x7ffc52dd0f00, 0x0, 0x0)
	/sd/workspace/src/github.com/screwdriver-cd/store-cli/sdstore/sdstore.go:196 +0xc41
main.set(0x7ffc52dd0fec, 0x8, 0x0, 0x0, 0x7ffc52dd0fd5, 0xf, 0x0, 0x0)
	/sd/workspace/src/github.com/screwdriver-cd/store-cli/store-cli.go:155 +0x1f6
main.main.func2(0xc0000dc580, 0x0, 0xc00009a560)
	/sd/workspace/src/github.com/screwdriver-cd/store-cli/store-cli.go:253 +0xef
github.com/urfave/cli.HandleAction(0x786a60, 0x814168, 0xc0000dc580, 0xc0000dc580, 0x0)
	/go/pkg/mod/github.com/urfave/cli@v1.21.0/app.go:514 +0xbe
github.com/urfave/cli.Command.Run(0x7fbf93, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x803829, 0x1b, 0x0, ...)
	/go/pkg/mod/github.com/urfave/cli@v1.21.0/command.go:171 +0x4d2
github.com/urfave/cli.(*App).Run(0xc0000fc000, 0xc00009a040, 0x4, 0x4, 0x0, 0x0)
	/go/pkg/mod/github.com/u
```

## Objective

Output the stack trace as a string.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
