### PR TITLE
Add null pointer check to filte write logic

### DIFF
--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -354,7 +354,7 @@ func (s *sdStore) putFile(url *url.URL, bodyType string, filePath string) error 
 		fsize := stat.Size()
 
 		res, err := s.put(url, bodyType, input, fsize)
-		if err != nil {
+		if res != nil {
 			defer res.Body.Close()
 		}
 

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -354,7 +354,9 @@ func (s *sdStore) putFile(url *url.URL, bodyType string, filePath string) error 
 		fsize := stat.Size()
 
 		res, err := s.put(url, bodyType, input, fsize)
-		defer res.Body.Close()
+		if err != nil {
+			defer res.Body.Close()
+		}
 
 		retry, err := s.checkForRetry(res, err)
 


### PR DESCRIPTION
## Context

Artifact upload in store-cli fails intermittently while writing file with error ERROR: runtime error: invalid memory address or nil pointer dereference

## Objective

This PR will check for res not nil and then call close the connection. We want the retry logic to process in case the correct response status is not received. 

*If the returned error is nil, the Response will contain a non-nil Body which the user is expected to close. If the Body is not both read to EOF and closed, the Client's underlying RoundTripper (typically Transport) may not be able to re-use a persistent TCP connection to the server for a subsequent "keep-alive" request.*

## Reference

http://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/#anameclose_http_resp_bodyaclosinghttpresponsebody

https://stackoverflow.com/questions/33238518/what-could-happen-if-i-dont-close-response-body-in-golang

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
