### PR TITLE
fix(1906): increase compression speed using flate

### DIFF
--- a/sdstore/ziphelper.go
+++ b/sdstore/ziphelper.go
@@ -2,6 +2,7 @@ package sdstore
 
 import (
 	"archive/zip"
+	"compress/flate"
 	"fmt"
 	"io"
 	"log"
@@ -43,14 +44,18 @@ var compressedFormats = map[string]struct{}{
 // Zip is repurposed from https://github.com/mholt/archiver/pull/92/files
 // To include support for symbolic links
 func Zip(source, target string) error {
-	zipfile, err := os.Create(target)
+	zipFile, err := os.Create(target)
 	if err != nil {
 		return err
 	}
-	defer zipfile.Close()
+	defer zipFile.Close()
 
-	w := zip.NewWriter(zipfile)
+	w := zip.NewWriter(zipFile)
 	defer w.Close()
+
+	w.RegisterCompressor(zip.Deflate, func(out io.Writer) (io.WriteCloser, error) {
+		return flate.NewWriter(out, flate.BestSpeed)
+	})
 
 	sourceInfo, err := os.Stat(source)
 	if err != nil {


### PR DESCRIPTION
## Context

Compressing build-cache files is slower.

## Objective

This PR will increase compression speed using flate.BestSpeed

## References

https://github.com/screwdriver-cd/screwdriver/issues/1906

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
