### PR TITLE
fix(1906): revert - increase compression speed using flate

### DIFF
--- a/sdstore/ziphelper.go
+++ b/sdstore/ziphelper.go
@@ -2,7 +2,6 @@ package sdstore
 
 import (
 	"archive/zip"
-	"compress/flate"
 	"fmt"
 	"io"
 	"log"
@@ -44,18 +43,14 @@ var compressedFormats = map[string]struct{}{
 // Zip is repurposed from https://github.com/mholt/archiver/pull/92/files
 // To include support for symbolic links
 func Zip(source, target string) error {
-	zipFile, err := os.Create(target)
+	zipfile, err := os.Create(target)
 	if err != nil {
 		return err
 	}
-	defer zipFile.Close()
+	defer zipfile.Close()
 
-	w := zip.NewWriter(zipFile)
+	w := zip.NewWriter(zipfile)
 	defer w.Close()
-
-	w.RegisterCompressor(zip.Deflate, func(out io.Writer) (io.WriteCloser, error) {
-		return flate.NewWriter(out, flate.BestSpeed)
-	})
 
 	sourceInfo, err := os.Stat(source)
 	if err != nil {


### PR DESCRIPTION
Reverts screwdriver-cd/store-cli#56

Based on the below timings, don't see much difference between default compression and best speed, so reverting zip best speed compression to default compression.

zip default compression timings
1st run - 815MB - cache set - 11 secs 
2nd run - 815MB - cache set - 11 secs
3rd run - 815MB - cache set - 11 secs 

1st run - 815MB - cache get - 10 secs
2nd run - 815MB - cache get - 10 secs
3rd run - 815MB - cache get - 10 secs

zip best speed compression timings
1st run - 815MB - cache set - 11 secs 
2nd run - 815MB - cache set - 11 secs
3rd run - 815MB - cache set - 11 secs 

1st run - 815MB - cache get - 10 secs
2nd run - 815MB - cache get - 9 secs
3rd run - 815MB - cache get - 10 secs
