### PR TITLE
fix(1931): fix get cache oom error

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,38 +1,53 @@
 package logger
 
 import (
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	"os"
+)
+
+var logger = log.WithFields(log.Fields{"app": "store-cli"})
+
+const (
+	LOGLEVEL_ERROR = log.ErrorLevel
+	LOGLEVEL_WARN  = log.WarnLevel
+	LOGLEVEL_INFO  = log.InfoLevel
+)
+
+const (
+	ERRTYPE_COPY         = "copy"
+	ERRTYPE_SCOPE        = "scope"
+	ERRTYPE_COMMAND      = "command"
+	ERRTYPE_FILE         = "file"
+	ERRTYPE_MD5          = "md5"
+	ERRTYPE_ZIP          = "zip"
+	ERRTYPE_MAXSIZELIMIT = "maxsizelimit"
 )
 
 func init() {
 	log.SetFormatter(&log.JSONFormatter{PrettyPrint: true})
 	log.SetOutput(os.Stdout)
-	log.SetLevel(log.WarnLevel)
+	log.SetLevel(log.ErrorLevel)
 }
 
-var logger = log.WithFields(log.Fields{"app": "store-cli"})
-
-const (
-	WARN         = "warn"
-	COPY         = "copy"
-	SCOPE        = "scope"
-	COMMAND      = "command"
-	MAXSIZELIMIT = "maxsizelimit"
-	INFO         = "info"
-	ERROR        = "error"
-	FILE         = "file"
-	MD5          = "md5"
-	ZIP          = "zip"
-)
-
-func Log(level, module, errType string, v ...interface{}) {
+/*
+write log
+param - level         		log level
+param - errType
+param - msg			error msg
+return - error / nil		INFO / WARN - nil; ERROR - return error msg
+*/
+func Log(level log.Level, module, errType string, msg ...interface{}) error {
 	switch level {
-	case "info":
-		logger.WithFields(log.Fields{"module": module, "type": errType}).Info(v...)
-	case "warn":
-		logger.WithFields(log.Fields{"module": module, "type": errType}).Warn(v...)
-	case "error":
-		logger.WithFields(log.Fields{"module": module, "type": errType}).Error(v...)
+	case log.WarnLevel:
+		msg = append([]interface{}{"ignore warning, "}, msg...)
+		logger.WithFields(log.Fields{"module": module, "type": errType}).Warn(msg...)
+		return nil
+	case log.ErrorLevel:
+		logger.WithFields(log.Fields{"module": module, "type": errType}).Error(msg...)
+		return fmt.Errorf(fmt.Sprintf("%v", msg...))
+	default:
+		logger.WithFields(log.Fields{"module": module, "type": errType}).Info(msg...)
+		return nil
 	}
 }

--- a/sdstore/md5helper.go
+++ b/sdstore/md5helper.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/screwdriver-cd/store-cli/logger"
 )
 
 // md5Hash struct with file, md5, total bytes, error
@@ -29,6 +31,8 @@ type result struct {
 	sum  string
 	err  error
 }
+
+const Md5helperModule = "md5helper"
 
 // get md5Hash for given file
 func getMd5Hash(filePath string) (string, int64, error) {
@@ -192,7 +196,8 @@ func GenerateMd5(path string) (map[string]string, error) {
 	}
 	totalFiles := float64(len(files))
 	batchSize := math.Ceil(totalFiles / float64(MaxConcurrencyLimit))
-	fmt.Printf("batch size: %d, concurreny limit: %d, total files: %d\n", int(batchSize), int(MaxConcurrencyLimit), int(totalFiles))
+	msg := fmt.Sprintf("batch size: %d, concurreny limit: %d, total files: %d\n", int(batchSize), int(MaxConcurrencyLimit), int(totalFiles))
+	logger.Log(logger.LOGLEVEL_INFO, Md5helperModule, "", msg)
 
 	k := 0
 	for i := 0; i < int(batchSize); i++ {

--- a/sdstore/ziphelper.go
+++ b/sdstore/ziphelper.go
@@ -174,10 +174,10 @@ func Unzip(src string, dest string) ([]string, error) {
 
 			// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
 			if dest != "/" && !strings.HasPrefix(fPath, filepath.Clean(dest)+string(os.PathSeparator)) {
-				msg := fmt.Sprintf("%s: illegal file path", fPath)
+				msg := fmt.Errorf("%s: illegal file path", fPath)
 				logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
 
-				return fPath, fTime, fmt.Errorf("%s: illegal file path", fPath)
+				return fPath, fTime, msg
 			}
 
 			if file.FileInfo().IsDir() {


### PR DESCRIPTION
## Context

Get cache fails with OOM error if the cache has more than 20000 files

## Objective

This PR will fix the get cache OOM error and refactor store-cli logging

## References

[1931](https://github.com/screwdriver-cd/screwdriver/issues/1931)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
