### PR TITLE
fix(2098): store cache with relative path

### DIFF
--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -310,13 +310,6 @@ func Cache2Disk(command, cacheScope, srcDir string, compress, md5Check bool, cac
 		}
 	}
 
-	/*
-	if srcDir, err = filepath.Abs(srcDir); err != nil {
-		msg = fmt.Sprintf("%v in src path %v, command: %v", err, srcDir, command)
-		return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_FILE, msg)
-	}
-	*/
-
 	if baseCacheDir, err = filepath.Abs(baseCacheDir); err != nil {
 		msg = fmt.Sprintf("%v in path %v, command: %v", err, baseCacheDir, command)
 		return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_FILE, msg)

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -309,7 +309,6 @@ func Cache2Disk(command, cacheScope, srcDir string, compress, md5Check bool, cac
 			return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_FILE, msg)
 		}
 	}
-	srcDir = strings.TrimPrefix(srcDir, "./")
 	if baseCacheDir, err = filepath.Abs(baseCacheDir); err != nil {
 		msg = fmt.Sprintf("%v in path %v, command: %v", err, baseCacheDir, command)
 		return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_FILE, msg)

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -309,7 +309,7 @@ func Cache2Disk(command, cacheScope, srcDir string, compress, md5Check bool, cac
 			return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_FILE, msg)
 		}
 	}
-
+	srcDir = strings.TrimPrefix(srcDir, "./")
 	if baseCacheDir, err = filepath.Abs(baseCacheDir); err != nil {
 		msg = fmt.Sprintf("%v in path %v, command: %v", err, baseCacheDir, command)
 		return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_FILE, msg)

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -140,11 +140,17 @@ func getCache(src, dest, command string, compress bool) error {
 		}
 
 		targetZipPath := fmt.Sprintf("%s.zip", dest)
-
 		if err = copy.Copy(srcZipPath, targetZipPath); err != nil {
 			return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_COPY, err)
 		}
-		_, err = Unzip(targetZipPath, filepath.Dir(dest))
+		// destination is relative without subdirectories, unzip in SD Source Directory
+		filePath := dest
+		dest, _ := filepath.Split(filePath)
+		if !strings.HasPrefix(filePath, "/") {
+			wd, _ := os.Getwd()
+			dest = filepath.Join(wd, dest)
+		}
+		_, err = Unzip(targetZipPath, dest)
 		if err != nil {
 			logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_ZIP, fmt.Sprintf("could not unzip file %s", src))
 		}
@@ -293,15 +299,23 @@ func Cache2Disk(command, cacheScope, srcDir string, compress, md5Check bool, cac
 	if strings.HasPrefix(baseCacheDir, "~/") {
 		baseCacheDir = filepath.Join(homeDir, strings.TrimPrefix(baseCacheDir, "~/"))
 	}
-
 	if strings.HasPrefix(srcDir, "~/") {
 		srcDir = filepath.Join(homeDir, strings.TrimPrefix(srcDir, "~/"))
 	}
+	srcDir = filepath.Clean(srcDir)
+	if strings.HasPrefix(srcDir, "../") {
+		if srcDir, err = filepath.Abs(srcDir); err != nil {
+			msg = fmt.Sprintf("%v in src path %v, command: %v", err, srcDir, command)
+			return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_FILE, msg)
+		}
+	}
 
+	/*
 	if srcDir, err = filepath.Abs(srcDir); err != nil {
 		msg = fmt.Sprintf("%v in src path %v, command: %v", err, srcDir, command)
 		return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_FILE, msg)
 	}
+	*/
 
 	if baseCacheDir, err = filepath.Abs(baseCacheDir); err != nil {
 		msg = fmt.Sprintf("%v in path %v, command: %v", err, baseCacheDir, command)

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -104,6 +104,10 @@ func (s *sdStore) Download(url *url.URL, toExtract bool) error {
 	log.Printf("filePath = %s", filePath)
 	if filePath != "" {
 		dir, _ := filepath.Split(filePath)
+		if !strings.HasPrefix(filePath, "/") {
+			wd, _ := os.Getwd()
+			dir = filepath.Join(wd, dir)
+		}
 		err = os.MkdirAll(dir, 0777)
 		if err != nil {
 			return err

--- a/store-cli.go
+++ b/store-cli.go
@@ -93,7 +93,6 @@ func makeURL(storeType, scope, key string) (*url.URL, error) {
 		if strings.HasPrefix(key, "../") {
 			key, _ = filepath.Abs(key)
 		}
-		key = strings.TrimPrefix(key, "./")
 		key = strings.TrimRight(key, "/")
 		encoded := url.PathEscape(key)
 		path = "caches/" + scope + "s/" + scopeEnv + "/" + encoded

--- a/store-cli.go
+++ b/store-cli.go
@@ -93,6 +93,7 @@ func makeURL(storeType, scope, key string) (*url.URL, error) {
 		if strings.HasPrefix(key, "../") {
 			key, _ = filepath.Abs(key)
 		}
+		key = strings.TrimPrefix(key, "./")
 		key = strings.TrimRight(key, "/")
 		encoded := url.PathEscape(key)
 		path = "caches/" + scope + "s/" + scopeEnv + "/" + encoded

--- a/store-cli.go
+++ b/store-cli.go
@@ -10,8 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/screwdriver-cd/store-cli/sdstore"
 	"github.com/urfave/cli"
+
+	"github.com/screwdriver-cd/store-cli/sdstore"
 )
 
 // VERSION gets set by the build script via the LDFLAGS
@@ -84,11 +85,14 @@ func makeURL(storeType, scope, key string) (*url.URL, error) {
 	var path string
 	switch storeType {
 	case "cache":
-		// if path is relative, get abs path
-		if strings.HasPrefix(key, "/") == false {
+		key = filepath.Clean(key)
+		homeDir, _ := os.UserHomeDir()
+		if strings.HasPrefix(key, "~/") {
+			key = filepath.Join(homeDir, strings.TrimPrefix(key, "~/"))
+		}
+		if strings.HasPrefix(key, "../") {
 			key, _ = filepath.Abs(key)
 		}
-
 		key = strings.TrimRight(key, "/")
 		encoded := url.PathEscape(key)
 		path = "caches/" + scope + "s/" + scopeEnv + "/" + encoded

--- a/store-cli_test.go
+++ b/store-cli_test.go
@@ -62,8 +62,8 @@ func TestMakeURL(t *testing.T) {
 	}{
 		{"cache", "job", "/myprcache", "http://store.screwdriver.cd/v1/caches/jobs/987/%2Fmyprcache"},
 		{"cache", "event", "/mycache", "http://store.screwdriver.cd/v1/caches/events/499/%2Fmycache"},
-		{"cache", "event", "mycache", fmt.Sprintf("%s%s%s", "http://store.screwdriver.cd/v1/caches/events/499/", abspath, "%2Fmycache")},
-		{"cache", "event", "./mycache", fmt.Sprintf("%s%s%s", "http://store.screwdriver.cd/v1/caches/events/499/", abspath, "%2Fmycache")},
+		{"cache", "event", "mycache", fmt.Sprintf("%s%s", "http://store.screwdriver.cd/v1/caches/events/499/", "mycache")},
+		{"cache", "event", "./mycache", fmt.Sprintf("%s%s", "http://store.screwdriver.cd/v1/caches/events/499/", "mycache")},
 		{"cache", "event", "/tmp/mycache/1/2/3/4/", "http://store.screwdriver.cd/v1/caches/events/499/%2Ftmp%2Fmycache%2F1%2F2%2F3%2F4"},
 		{"cache", "event", "/!-_.*'()&@:,.$=+?; space", "http://store.screwdriver.cd/v1/caches/events/499/%2F%21-_.%2A%27%28%29&@:%2C.$=+%3F%3B%20space"},
 		{"artifact", "event", "artifact-1", "http://store.screwdriver.cd/v1/builds/10038/ARTIFACTS/artifact-1"},


### PR DESCRIPTION
## Context

store-cli not able to store and get cache with relative path resolution

## Objective

store-cli to support relative path, users should be able to cache a directory or file and get it under any directory.

ex: store cache `test (path: sd/workspace/src/**user1**/test)` and get `test (path: sd/workspace/src/**user2**/test)`

note: same folder/file name under two different paths cannot be stored with relative path, one folder has to be stored with absolute path

## References

[store-cli to not able to store and get cache with relative path resolution](https://github.com/screwdriver-cd/screwdriver/issues/2098)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
