### PR TITLE
fix: error in generating md5 for directory more than 40k files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,10 @@ require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/karrick/godirwalk v1.14.0
 	github.com/otiai10/copy v1.0.2
+	github.com/pieterclaerhout/go-waitgroup v1.0.7
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.22.2
 	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli v1.21.0 h1:wYSSj06510qPIzGSua9ZqsncMmWE3Zr55KBERygyrxE=
 github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
@@ -43,6 +44,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ry
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/pieterclaerhout/go-waitgroup v1.0.7 h1:W9zHJzXO3SPo7Rb3E8hkk8D0gJPdP6DWENt6M08IxWE=
+github.com/pieterclaerhout/go-waitgroup v1.0.7/go.mod h1:TJIzZKRP4sc5AT8M0RVUwXhw/OWMxg/lW8VsQz4SRBo=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -32,10 +34,12 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli v1.21.0 h1:wYSSj06510qPIzGSua9ZqsncMmWE3Zr55KBERygyrxE=
 github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -90,7 +90,7 @@ func removeCacheDirectory(path, md5Path string) {
 	_, err := os.Lstat(path)
 
 	if err != nil {
-		logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, fmt.Sprintf("%v: No such file or directory", path))
+		logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, fmt.Sprintf("error: %v\n", err))
 	} else {
 		if err := os.RemoveAll(md5Path); err != nil {
 			logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, fmt.Sprintf("failed to clean out %v.md5 file: %v", filepath.Base(path), md5Path))
@@ -116,7 +116,6 @@ func getCache(src, dest, command string, compress bool) error {
 	logger.Log(logger.LOGLEVEL_INFO, "", "", "get cache")
 	info, err := os.Lstat(src)
 	if err != nil {
-		fmt.Printf("%v: No such file or directory\n", src)
 		msg = fmt.Sprintf("directory [%v] check failed, do file check %v", src, command)
 		logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, msg)
 	}
@@ -347,8 +346,8 @@ func Cache2Disk(command, cacheScope, srcDir string, compress, md5Check bool, cac
 		destPath := dest
 
 		if err != nil {
-			fmt.Printf("%v: No such file or directory", dest)
-			logger.Log(logger.LOGLEVEL_WARN, "", "", fmt.Sprintf("%v: No such file or directory", dest))
+			fmt.Printf("error: %v\n", err)
+			logger.Log(logger.LOGLEVEL_WARN, "", "", fmt.Sprintf("error: %v", err))
 		} else {
 			if !info.IsDir() {
 				destPath = filepath.Dir(dest)

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -90,7 +90,7 @@ func removeCacheDirectory(path, md5Path string) {
 	_, err := os.Lstat(path)
 
 	if err != nil {
-		logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, fmt.Sprintf("cache directory does not exist: %v", path))
+		logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, fmt.Sprintf("cache %v does not exist", path))
 	} else {
 		if err := os.RemoveAll(md5Path); err != nil {
 			logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, fmt.Sprintf("failed to clean out %v.md5 file: %v", filepath.Base(path), md5Path))
@@ -116,6 +116,7 @@ func getCache(src, dest, command string, compress bool) error {
 	logger.Log(logger.LOGLEVEL_INFO, "", "", "get cache")
 	info, err := os.Lstat(src)
 	if err != nil {
+		fmt.Printf("%v: No such file or directory\n", src)
 		msg = fmt.Sprintf("directory [%v] check failed, do file check %v", src, command)
 		logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, msg)
 	}
@@ -197,6 +198,7 @@ func setCache(src, dest, command string, compress, md5Check bool, cacheMaxSizeIn
 
 	if cacheMaxSizeInMB > 0 {
 		sizeInMB := int64(float64(getSizeInBytes(src)) * 0.000001)
+		fmt.Printf("size: %vMB\n", sizeInMB)
 		if sizeInMB > cacheMaxSizeInMB {
 			msg = fmt.Sprintf("source directory size %vMB is more than allowed max limit %vMB", sizeInMB, cacheMaxSizeInMB)
 			return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_MAXSIZELIMIT, msg)
@@ -325,27 +327,28 @@ func Cache2Disk(command, cacheScope, srcDir string, compress, md5Check bool, cac
 
 	switch command {
 	case "set":
-		fmt.Println("set cache")
+		fmt.Printf("set cache, scope: %v, path: %v\n", cacheScope, srcDir)
 		if err = setCache(src, dest, command, compress, md5Check, cacheMaxSizeInMB); err != nil {
 			return logger.Log(logger.LOGLEVEL_ERROR, "", "", fmt.Sprintf("set cache FAILED"))
 		}
 		fmt.Println("set cache completed")
 	case "get":
-		fmt.Println("get cache")
 		src = cacheDir
 		dest = srcDir
+		fmt.Printf("get cache, scope: %v, path: %v\n", cacheScope, srcDir)
 		if err = getCache(src, dest, command, compress); err != nil {
 			logger.Log(logger.LOGLEVEL_WARN, "", "", fmt.Sprintf("get cache FAILED"))
 		}
 		fmt.Println("get cache completed")
 	case "remove":
-		fmt.Println("remove cache")
+		fmt.Printf("remove cache, scope: %v, directory: %v\n", cacheScope, srcDir)
 		info, err := os.Lstat(dest)
 		destBase := filepath.Base(dest)
 		destPath := dest
 
 		if err != nil {
-			logger.Log(logger.LOGLEVEL_WARN, "", "", fmt.Sprintf("path %v does not exist", dest))
+			fmt.Printf("%v: No such file or directory", dest)
+			logger.Log(logger.LOGLEVEL_WARN, "", "", fmt.Sprintf("%v: No such file or directory", dest))
 		} else {
 			if !info.IsDir() {
 				destPath = filepath.Dir(dest)

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -165,6 +165,7 @@ func getCache(src, dest, command string, compress bool) error {
 	if info.IsDir() {
 		defer os.RemoveAll(filepath.Join(dest, fmt.Sprintf("%s%s", filepath.Base(dest), ".md5")))
 	}
+	fmt.Println("get cache SUCCESS")
 	return logger.Log(logger.LOGLEVEL_INFO, "", "", "get cache complete")
 }
 
@@ -326,21 +327,20 @@ func Cache2Disk(command, cacheScope, srcDir string, compress, md5Check bool, cac
 
 	switch command {
 	case "set":
-		fmt.Printf("set cache, scope: %v, path: %v\n", cacheScope, srcDir)
+		fmt.Printf("set cache -> {scope: %v, path: %v} \n", cacheScope, srcDir)
 		if err = setCache(src, dest, command, compress, md5Check, cacheMaxSizeInMB); err != nil {
 			return logger.Log(logger.LOGLEVEL_ERROR, "", "", fmt.Sprintf("set cache FAILED"))
 		}
-		fmt.Println("set cache completed")
+		fmt.Println("set cache SUCCESS")
 	case "get":
 		src = cacheDir
 		dest = srcDir
-		fmt.Printf("get cache, scope: %v, path: %v\n", cacheScope, srcDir)
+		fmt.Printf("get cache -> {scope: %v, path: %v} \n", cacheScope, srcDir)
 		if err = getCache(src, dest, command, compress); err != nil {
 			logger.Log(logger.LOGLEVEL_WARN, "", "", fmt.Sprintf("get cache FAILED"))
 		}
-		fmt.Println("get cache completed")
 	case "remove":
-		fmt.Printf("remove cache, scope: %v, directory: %v\n", cacheScope, srcDir)
+		fmt.Printf("remove cache -> {scope: %v, path: %v} \n", cacheScope, srcDir)
 		info, err := os.Lstat(dest)
 		destBase := filepath.Base(dest)
 		destPath := dest
@@ -356,7 +356,7 @@ func Cache2Disk(command, cacheScope, srcDir string, compress, md5Check bool, cac
 
 			removeCacheDirectory(dest, filepath.Join(destPath, fmt.Sprintf("%s%s", destBase, ".md5")))
 		}
-		fmt.Println("remove cache completed")
+		fmt.Println("remove cache SUCCESS")
 	}
 	return nil
 }

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -90,7 +90,7 @@ func removeCacheDirectory(path, md5Path string) {
 	_, err := os.Lstat(path)
 
 	if err != nil {
-		logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, fmt.Sprintf("cache %v does not exist", path))
+		logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, fmt.Sprintf("%v: No such file or directory", path))
 	} else {
 		if err := os.RemoveAll(md5Path); err != nil {
 			logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_FILE, fmt.Sprintf("failed to clean out %v.md5 file: %v", filepath.Base(path), md5Path))

--- a/sdstore/md5helper.go
+++ b/sdstore/md5helper.go
@@ -198,7 +198,7 @@ return - md5map / error	success - return md5map; error - return error descriptio
 func GenerateMd5(path string) (map[string]string, error) {
 	var rwm sync.RWMutex
 	md5Map := make(map[string]string)
-	maxGoRoutines, _ := strconv.Atoi(getEnv("SD_CACHE_MAX_GO_WORKERS", "10000"))
+	maxGoRoutines, _ := strconv.Atoi(getEnv("SD_CACHE_MAX_GO_THREADS", "10000"))
 	wg := waitgroup.NewWaitGroup(maxGoRoutines)
 
 	files, err := getAllFiles(path)

--- a/sdstore/md5helper.go
+++ b/sdstore/md5helper.go
@@ -48,7 +48,7 @@ func getMd5Hash(wg *sync.WaitGroup, filePath string) (string, int64, error) {
 	md5hash := md5.New()
 	b, err := io.Copy(md5hash, file)
 	if err != nil {
-		return "", b, err
+		return "", 0, err
 	}
 
 	md5hashInBytes := md5hash.Sum(nil)[:16]

--- a/sdstore/md5helper.go
+++ b/sdstore/md5helper.go
@@ -198,7 +198,7 @@ return - md5map / error	success - return md5map; error - return error descriptio
 func GenerateMd5(path string) (map[string]string, error) {
 	var rwm sync.RWMutex
 	md5Map := make(map[string]string)
-	maxGoRoutines, _ := strconv.Atoi(getEnv("SD_CACHE_MAX_GO_ROUTINES", "5000"))
+	maxGoRoutines, _ := strconv.Atoi(getEnv("SD_CACHE_MAX_GO_WORKERS", "10000"))
 	wg := waitgroup.NewWaitGroup(maxGoRoutines)
 
 	files, err := getAllFiles(path)

--- a/sdstore/md5helper.go
+++ b/sdstore/md5helper.go
@@ -198,8 +198,8 @@ return - md5map / error	success - return md5map; error - return error descriptio
 func GenerateMd5(path string) (map[string]string, error) {
 	var rwm sync.RWMutex
 	md5Map := make(map[string]string)
-	maxGoRoutines, _ := strconv.Atoi(getEnv("SD_CACHE_MAX_GO_THREADS", "10000"))
-	wg := waitgroup.NewWaitGroup(maxGoRoutines)
+	maxGoThreads, _ := strconv.Atoi(getEnv("SD_CACHE_MAX_GO_THREADS", "10000"))
+	wg := waitgroup.NewWaitGroup(maxGoThreads)
 
 	files, err := getAllFiles(path)
 	if err != nil {

--- a/sdstore/md5helper.go
+++ b/sdstore/md5helper.go
@@ -40,15 +40,14 @@ func getMd5Hash(wg *sync.WaitGroup, filePath string) (string, int64, error) {
 
 	defer wg.Done()
 	file, err := os.Open(filePath)
-	defer file.Close()
-
 	if err != nil {
 		return "", 0, err
 	}
+	defer file.Close()
+
 	md5hash := md5.New()
 	b, err := io.Copy(md5hash, file)
 	if err != nil {
-		fmt.Printf("iocopy error")
 		return "", b, err
 	}
 

--- a/sdstore/ziphelper.go
+++ b/sdstore/ziphelper.go
@@ -236,7 +236,7 @@ func Unzip(src string, dest string) ([]string, error) {
 	for _, ft := range filesTime {
 		if err := os.Chtimes(ft.path, time.Now(), ft.modtime); err != nil {
 			msg := fmt.Sprintf("failed to update file timestamps: %v", err)
-			logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
+			logger.Log(logger.LOGLEVEL_WARN, ZiphelperModule, "", msg)
 		}
 	}
 


### PR DESCRIPTION
## Context

getMd5Hash function returns error for directories having more than 40k files. 

`panic: send on closed channel
00:00:24 
00:00:24 goroutine 35419 [running]:
00:00:24 github.com/screwdriver-cd/store-cli/sdstore.GenerateMd5.func1(0xc00040dd60, 0xc00029f080, 0xc000a00700, 0x66)
00:00:24 	/sd/workspace/src/github.com/screwdriver-cd/store-cli/sdstore/md5helper.go:209 +0xdb
00:00:24 created by github.com/screwdriver-cd/store-cli/sdstore.GenerateMd5
00:00:24 	/sd/workspace/src/github.com/screwdriver-cd/store-cli/sdstore/md5helper.go:206 +0x376
`

## Objective

update concurrency control and add logs to display cache size.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
