### PR TITLE
fix: env defaults to be handled by config

### DIFF
--- a/sdstore/md5helper.go
+++ b/sdstore/md5helper.go
@@ -37,15 +37,6 @@ type result struct {
 
 const Md5helperModule = "md5helper"
 
-// getEnv get key environment variable if exist otherwise return defaultValue
-func getEnv(key, defaultValue string) string {
-	value := os.Getenv(key)
-	if len(value) == 0 {
-		return defaultValue
-	}
-	return value
-}
-
 // get md5Hash for given file
 func getMd5Hash(filePath string) (string, int64, error) {
 	var md5str string
@@ -198,7 +189,7 @@ return - md5map / error	success - return md5map; error - return error descriptio
 func GenerateMd5(path string) (map[string]string, error) {
 	var rwm sync.RWMutex
 	md5Map := make(map[string]string)
-	maxGoThreads, _ := strconv.Atoi(getEnv("SD_CACHE_MAX_GO_THREADS", "10000"))
+	maxGoThreads, _ := strconv.Atoi(os.Getenv("SD_CACHE_MAX_GO_THREADS"))
 	wg := waitgroup.NewWaitGroup(maxGoThreads)
 
 	files, err := getAllFiles(path)


### PR DESCRIPTION
## Context

Environment defaults to be configured via api and worker config yaml.

## Objective

Remove function getEnv which returns env default value if not available

## References

https://github.com/screwdriver-cd/store-cli/pull/61

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
