### PR TITLE
fix: log messages and md5check analysis

### DIFF
--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -297,7 +297,7 @@ func setCache(src, dest, command string, compress, md5Check bool, cacheMaxSizeIn
 		err = ExecuteCommand(cmd)
 		if err != nil {
 			msg = fmt.Sprintf("failed to compress files from %v", src)
-			return logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_ZIP, msg)
+			return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_ZIP, msg)
 		}
 		_ = os.Chmod(destPath, 0777)
 

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -194,7 +194,7 @@ func getCache(src, dest, command string, compress bool) error {
 				err = ExecuteCommand(cmd)
 				if err != nil {
 					msg = fmt.Sprintf("failed to decompress files from %v", src)
-					return logger.Log(logger.LOGLEVEL_WARN, "", logger.ERRTYPE_ZIP, msg)
+					return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_ZIP, msg)
 				}
 				_ = os.Chmod(destPath, 0777)
 			}


### PR DESCRIPTION
## Context

Fix log messages and close files and rwm locks immediately after use. 

Observation: md5 check takes more time if # of files (660761) and size (~7.3GB) is relatively high in the cache folder. 

## References

https://github.com/screwdriver-cd/store-cli/pull/66

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
