### PR TITLE
fix: check files meta only and not md5

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,6 +11,10 @@ jobs:
         steps:
             - vet: go vet ./...
             - gofmt: ret=$(find . -name '*.go' | xargs gofmt -d) && echo "$ret" && test -z "$ret"
+            - pretest-setup: |
+                wget -q -O zstd-cli-linux.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-linux.tar.gz'
+                tar -C . -ozxvf zstd-cli-linux.tar.gz
+                chmod +x zstd-cli-linux
             - test-setup: go get gotest.tools/gotestsum@v0.6.0
             - test: gotestsum --format testname --jsonfile ${SD_ARTIFACTS_DIR}/report.json -- -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out ./...
             - build: go build -a -o store-cli

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -15,6 +15,7 @@ jobs:
                 wget -q -O zstd-cli-linux.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-linux.tar.gz'
                 tar -C . -ozxvf zstd-cli-linux.tar.gz
                 chmod +x zstd-cli-linux
+                cp zstd-cli-linux /usr/local/bin
             - test-setup: go get gotest.tools/gotestsum@v0.6.0
             - test: gotestsum --format testname --jsonfile ${SD_ARTIFACTS_DIR}/report.json -- -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out ./...
             - build: go build -a -o store-cli

--- a/sdstore/md5helper.go
+++ b/sdstore/md5helper.go
@@ -25,44 +25,6 @@ type result struct {
 
 const Md5helperModule = "md5helper"
 
-/*
-Get all files for given path
-param - path			file or folder path
-return - map[string]string / error	success - return meta map of files; error - return error description
-*/
-func getAllFiles(path string) (map[string]string, error) {
-	var metaMap = make(map[string]string)
-
-	err := godirwalk.Walk(path, &godirwalk.Options{
-		Callback: func(filePath string, de *godirwalk.Dirent) error {
-			if !de.ModeType().IsDir() {
-				stat, err := os.Stat(filePath)
-				if err == nil {
-					meta := fmt.Sprintf("%s %v %s %v %v %v", stat.Name(), stat.Size(), stat.ModTime(), stat.IsDir(), de.IsSymlink(), de.IsRegular())
-					metaMap[filePath] = meta
-				} else {
-					meta := fmt.Sprintf("%s", err)
-					metaMap[filePath] = meta
-				}
-			}
-			return nil
-		},
-		ErrorCallback: func(filePath string, err error) godirwalk.ErrorAction {
-			logger.Log(logger.LOGLEVEL_WARN, Md5helperModule, "", err)
-			return godirwalk.SkipNode
-		},
-		Unsorted:            false,
-		AllowNonDirectory:   true,
-		FollowSymbolicLinks: true,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return metaMap, err
-}
-
 func hashFromPath(filePath string) (string, error) {
 	var md5str string
 
@@ -157,11 +119,38 @@ func MD5All(root string) (map[string]string, error) {
 
 /*
 GenerateMeta reads files for given path, generates meta and returns metaMap or error
-param - path				file or folder path
-return - metamap / error	success - return metamap; error - return error description
+param - path			file or folder path
+return - map[string]string / error	success - return meta map of files; error - return error description
 */
-
 func GenerateMeta(path string) (map[string]string, error) {
-	metaMap, err := getAllFiles(path)
+	var metaMap = make(map[string]string)
+
+	err := godirwalk.Walk(path, &godirwalk.Options{
+		Callback: func(filePath string, de *godirwalk.Dirent) error {
+			if !de.ModeType().IsDir() {
+				stat, err := os.Stat(filePath)
+				if err == nil {
+					meta := fmt.Sprintf("%s %v %s %v %v %v", stat.Name(), stat.Size(), stat.ModTime(), stat.IsDir(), de.IsSymlink(), de.IsRegular())
+					metaMap[filePath] = meta
+				} else {
+					meta := fmt.Sprintf("%s", err)
+					metaMap[filePath] = meta
+				}
+			}
+			return nil
+		},
+		ErrorCallback: func(filePath string, err error) godirwalk.ErrorAction {
+			logger.Log(logger.LOGLEVEL_WARN, Md5helperModule, "", err)
+			return godirwalk.SkipNode
+		},
+		Unsorted:            false,
+		AllowNonDirectory:   true,
+		FollowSymbolicLinks: true,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
 	return metaMap, err
 }

--- a/sdstore/ziphelper.go
+++ b/sdstore/ziphelper.go
@@ -2,11 +2,9 @@ package sdstore
 
 import (
 	"archive/zip"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"sort"
@@ -44,9 +42,6 @@ var compressedFormats = map[string]struct{}{
 }
 
 const ZiphelperModule = "ziphelper"
-
-// ExecCommand : os exec command
-var ExecCommand = exec.Command
 
 // Zip is repurposed from https://github.com/mholt/archiver/pull/92/files
 // To include support for symbolic links
@@ -226,7 +221,7 @@ func Unzip(src string, dest string) ([]string, error) {
 		}(file)
 
 		if err != nil {
-			_ = logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+			logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
 			return files, err
 		}
 		files = append(files, fPath)
@@ -246,21 +241,4 @@ func Unzip(src string, dest string) ([]string, error) {
 	}
 
 	return files, nil
-}
-
-// ExecuteCommand : Execute shell commands
-// return output => executing shell command succeeds
-// return error => for any error
-func ExecuteCommand(command string) error {
-	_ = logger.Log(logger.LOGLEVEL_INFO, ZiphelperModule, "executeCommand", command)
-	cmd := ExecCommand("sh", "-c", command)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil || strings.TrimSpace(stderr.String()) != "" {
-		return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, logger.ERRTYPE_COPY, fmt.Sprintf("run err: %v, command err: %v, command out: %v", err, stderr.String(), stdout.String()))
-	}
-	_ = logger.Log(logger.LOGLEVEL_INFO, ZiphelperModule, stdout.String())
-	return nil
 }


### PR DESCRIPTION
## Context

Compare just file meta instead of md5 hash. Revert ziphelper.go common module changes, to rule out/narrow down Opensource screwdriver instance issue

## Objective

Remove md5 hash generation and just compare file metadata

## References

https://github.com/screwdriver-cd/store-cli/pull/66
https://github.com/screwdriver-cd/store-cli/pull/67

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
