### PR TITLE
fix: cleanup and perf fixes

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -19,7 +19,7 @@ const (
 	ERRTYPE_SCOPE        = "scope"
 	ERRTYPE_COMMAND      = "command"
 	ERRTYPE_FILE         = "file"
-	ERRTYPE_MD5          = "md5"
+	ERRTYPE_META         = "meta"
 	ERRTYPE_ZIP          = "zip"
 	ERRTYPE_MAXSIZELIMIT = "maxsizelimit"
 )

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,11 +11,6 @@ jobs:
         steps:
             - vet: go vet ./...
             - gofmt: ret=$(find . -name '*.go' | xargs gofmt -d) && echo "$ret" && test -z "$ret"
-            - pretest-setup: |
-                wget -q -O zstd-cli-linux.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-linux.tar.gz'
-                tar -C . -ozxvf zstd-cli-linux.tar.gz
-                chmod +x zstd-cli-linux
-                cp zstd-cli-linux /usr/local/bin
             - test-setup: go get gotest.tools/gotestsum@v0.6.0
             - test: gotestsum --format testname --jsonfile ${SD_ARTIFACTS_DIR}/report.json -- -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out ./...
             - build: go build -a -o store-cli

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -65,7 +65,7 @@ func getMetadataInfo(path string) (map[string]string, int64) {
 			return nil
 		}
 		if !file.IsDir() {
-			meta := fmt.Sprintf("%s %v %s %v %v", file.Name(), file.Size(), file.ModTime(), file.IsDir(), file.Mode())
+			meta := fmt.Sprintf("%v %s %v %v", file.Size(), file.ModTime(), file.IsDir(), file.Mode())
 			metaMap[path] = meta
 			sizes <- file.Size()
 		}

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -315,7 +315,7 @@ func setCache(src, dest, command string, compress, metaDataCheck bool, cacheMaxS
 			msg = fmt.Sprintf("failed to compress files from %v", src)
 			return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_ZIP, msg)
 		}
-		_ = os.Chmod(destPath, 0777)
+		_ = os.Chmod(targetPath, 0777)
 
 		// remove zip file if available
 		targetPath = fmt.Sprintf("%s%s", filepath.Join(destPath, destBase), CompressFormatZip)

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -316,6 +316,7 @@ func setCache(src, dest, command string, compress, metaDataCheck bool, cacheMaxS
 			return logger.Log(logger.LOGLEVEL_ERROR, "", logger.ERRTYPE_ZIP, msg)
 		}
 		_ = os.Chmod(targetPath, 0777)
+		_ = os.Chmod(destPath, 0777)
 
 		// remove zip file if available
 		targetPath = fmt.Sprintf("%s%s", filepath.Join(destPath, destBase), CompressFormatZip)

--- a/sdstore/cache2disk_test.go
+++ b/sdstore/cache2disk_test.go
@@ -108,7 +108,7 @@ func Test_SetCache_wCompress_File_CherryPick(t *testing.T) {
 			assert.Assert(t, Cache2Disk("set", cache[0], local, true, true, 0) == nil)
 			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -135,7 +135,7 @@ func Test_SetCache_wCompress_File(t *testing.T) {
 			assert.Assert(t, Cache2Disk("set", cache[0], local, true, true, 0) == nil)
 			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -162,7 +162,7 @@ func Test_SetCache_wCompress_RewriteFile_NODELTA(t *testing.T) {
 
 			// compress: true
 			assert.Assert(t, Cache2Disk("set", cache[0], local, true, true, 0) == nil)
-			info, _ = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			info, _ = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
 		}
 	}
@@ -216,7 +216,7 @@ func Test_SetCache_File_CherryPick(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -243,7 +243,7 @@ func Test_SetCache_File(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -271,13 +271,13 @@ func Test_SetCache_RewriteFile_NODELTA(t *testing.T) {
 
 			// compress: true
 			assert.Assert(t, Cache2Disk("set", cache[0], local, false, true, 0) == nil)
-			info, _ = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".md5")))
+			info, _ = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".meta")))
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
 		}
 	}
 }
 
-func Test_SetCache_File_NoMD5Check(t *testing.T) {
+func Test_SetCache_File_NoMETADATACheck(t *testing.T) {
 	cacheScope := []string{"pipeline:SD_PIPELINE_CACHE_DIR:../data/cache/pipeline", "job:SD_JOB_CACHE_DIR:../data/cache/job", "event:SD_EVENT_CACHE_DIR:../data/cache/event"}
 	localCacheFolders := []string{"../data/cache/.m2/testfolder1/testfolder1.txt", "../data/cache/maxsize/2mb"}
 
@@ -298,7 +298,7 @@ func Test_SetCache_File_NoMD5Check(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -350,7 +350,7 @@ func Test_RemoveCache_File(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.ErrorContains(t, err, "no such file or directory")
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -377,7 +377,7 @@ func Test_SetCache_wCompress_NewFolder_CherryPick(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -407,7 +407,7 @@ func Test_GetCache_wCompress_Folder_CherryPick(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -434,7 +434,7 @@ func Test_SetCache_wCompress_NewFolder(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -460,7 +460,7 @@ func Test_SetCache_wCompress_RewriteFolder_NODELTA(t *testing.T) {
 			local, _ := filepath.Abs(eachFolder)
 			assert.Assert(t, Cache2Disk("set", cache[0], local, true, true, 0) == nil)
 
-			info, _ = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			info, _ = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
 		}
 	}
@@ -490,7 +490,7 @@ func Test_GetCache_wCompress_Folder(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -521,7 +521,7 @@ func Test_GetCache_wCompress_Folder_doNOTOverwriteNewFilesInLocal(t *testing.T) 
 			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 
 			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", "donotoverwrite", ".txt")))
@@ -552,7 +552,7 @@ func Test_RemoveCache_Folder_wCompress(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.ErrorContains(t, err, "no such file or directory")
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -579,7 +579,7 @@ func Test_SetCache_NewFolder(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -610,14 +610,14 @@ func Test_SetCache_RewriteFolder_NODELTA(t *testing.T) {
 			info, _ := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			fmt.Printf("currentTime: [%v], file: [%v], createTime: [%v]\n", currentTime, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat), info.ModTime().Unix())
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
-			info, _ = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			info, _ = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			fmt.Printf("currentTime: [%v], file: [%v], createTime: [%v]\n", currentTime, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat), info.ModTime().Unix())
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
 		}
 	}
 }
 
-func Test_SetCache_NewFolder_NoMD5Check(t *testing.T) {
+func Test_SetCache_NewFolder_NoMETADATACheck(t *testing.T) {
 	cacheScope := []string{"pipeline:SD_PIPELINE_CACHE_DIR:../data/cache/pipeline", "job:SD_JOB_CACHE_DIR:../data/cache/job", "event:SD_EVENT_CACHE_DIR:../data/cache/event"}
 	localCacheFolders := []string{"../data/cache/.m2/testfolder1", "../data/cache/.m2/testfolder2"}
 
@@ -638,7 +638,7 @@ func Test_SetCache_NewFolder_NoMD5Check(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -665,7 +665,7 @@ func Test_GetCache_Folder(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -693,7 +693,7 @@ func Test_GetCache_Folder_doNOTOverwriteNewFilesInLocal(t *testing.T) {
 			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 
 			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", "donotoverwrite", ".txt")))
@@ -724,7 +724,7 @@ func Test_RemoveCache_Folder(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.ErrorContains(t, err, "no such file or directory")
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -757,7 +757,7 @@ func Test_SetCache_NewFolder_wCompress_wTilde(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -790,7 +790,7 @@ func Test_SetCache_NewFolder_wTilde(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, "testfolder1.txt"))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -864,7 +864,7 @@ func Test_SetCache_NewRelativeFolder_wCompress(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, eachFolder, fmt.Sprintf("%s%s", filepath.Base(eachFolder), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, eachFolder, fmt.Sprintf("%s%s", filepath.Base(eachFolder), ".md5")))
+			_, err = os.Lstat(filepath.Join(cacheDir, eachFolder, fmt.Sprintf("%s%s", filepath.Base(eachFolder), ".meta")))
 			assert.Assert(t, err == nil)
 		}
 	}

--- a/sdstore/md5helper.go
+++ b/sdstore/md5helper.go
@@ -6,11 +6,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
-	"fmt"
-	"github.com/karrick/godirwalk"
-	"github.com/screwdriver-cd/store-cli/logger"
 	"io"
-	// "math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -22,8 +18,6 @@ type result struct {
 	sum  string
 	err  error
 }
-
-const Md5helperModule = "md5helper"
 
 func hashFromPath(filePath string) (string, error) {
 	var md5str string
@@ -115,42 +109,4 @@ func MD5All(root string) (map[string]string, error) {
 		return nil, err
 	}
 	return m, nil
-}
-
-/*
-GenerateMeta reads files for given path, generates meta and returns metaMap or error
-param - path			file or folder path
-return - map[string]string / error	success - return meta map of files; error - return error description
-*/
-func GenerateMeta(path string) (map[string]string, error) {
-	var metaMap = make(map[string]string)
-
-	err := godirwalk.Walk(path, &godirwalk.Options{
-		Callback: func(filePath string, de *godirwalk.Dirent) error {
-			if !de.ModeType().IsDir() {
-				stat, err := os.Stat(filePath)
-				if err == nil {
-					meta := fmt.Sprintf("%s %v %s %v %v %v", stat.Name(), stat.Size(), stat.ModTime(), stat.IsDir(), de.IsSymlink(), de.IsRegular())
-					metaMap[filePath] = meta
-				} else {
-					meta := fmt.Sprintf("%s", err)
-					metaMap[filePath] = meta
-				}
-			}
-			return nil
-		},
-		ErrorCallback: func(filePath string, err error) godirwalk.ErrorAction {
-			logger.Log(logger.LOGLEVEL_WARN, Md5helperModule, "", err)
-			return godirwalk.SkipNode
-		},
-		Unsorted:            false,
-		AllowNonDirectory:   true,
-		FollowSymbolicLinks: true,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return metaMap, err
 }

--- a/store-cli.go
+++ b/store-cli.go
@@ -19,7 +19,7 @@ import (
 var VERSION string
 var CacheStrategy string = strings.ToLower(os.Getenv("SD_CACHE_STRATEGY"))
 var CacheCompress, _ = strconv.ParseBool(strings.ToLower(strings.TrimSpace(os.Getenv("SD_CACHE_COMPRESS"))))
-var CacheMd5Check, _ = strconv.ParseBool(strings.ToLower(strings.TrimSpace(os.Getenv("SD_CACHE_MD5CHECK"))))
+var CacheMetaDataCheck, _ = strconv.ParseBool(strings.ToLower(strings.TrimSpace(os.Getenv("SD_CACHE_MD5CHECK"))))
 var CacheMaxSizeInMB, _ = strconv.ParseInt(os.Getenv("SD_CACHE_MAX_SIZE_MB"), 0, 64)
 
 // successExit exits process with 0
@@ -121,7 +121,7 @@ func get(storeType, scope, key string) error {
 	}
 
 	if strings.ToLower(storeType) == "cache" && CacheStrategy == "disk" {
-		return sdstore.Cache2Disk("get", scope, key, CacheCompress, CacheMd5Check, CacheMaxSizeInMB)
+		return sdstore.Cache2Disk("get", scope, key, CacheCompress, CacheMetaDataCheck, CacheMaxSizeInMB)
 	} else {
 		sdToken := os.Getenv("SD_TOKEN")
 		fullURL, err := makeURL(storeType, scope, key)
@@ -151,7 +151,7 @@ func set(storeType, scope, filePath string) error {
 	}
 
 	if strings.ToLower(storeType) == "cache" && CacheStrategy == "disk" {
-		return sdstore.Cache2Disk("set", scope, filePath, CacheCompress, CacheMd5Check, CacheMaxSizeInMB)
+		return sdstore.Cache2Disk("set", scope, filePath, CacheCompress, CacheMetaDataCheck, CacheMaxSizeInMB)
 	} else {
 		sdToken := os.Getenv("SD_TOKEN")
 		fullURL, err := makeURL(storeType, scope, filePath)
@@ -180,7 +180,7 @@ func remove(storeType, scope, key string) error {
 	}
 
 	if strings.ToLower(storeType) == "cache" && CacheStrategy == "disk" {
-		return sdstore.Cache2Disk("remove", scope, key, CacheCompress, CacheMd5Check, CacheMaxSizeInMB)
+		return sdstore.Cache2Disk("remove", scope, key, CacheCompress, CacheMetaDataCheck, CacheMaxSizeInMB)
 	} else {
 		sdToken := os.Getenv("SD_TOKEN")
 		store := sdstore.NewStore(sdToken)


### PR DESCRIPTION
## Objective

In cache to disk route, we are walking thru the directory twice unnecessarily to get size and metadata, instead walk once and get both information. 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
