### PR TITLE
fix(2348): cache performance enhancements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/screwdriver-cd/store-cli
 
-go 1.12
+go 1.15
 
 require (
 	github.com/google/go-cmp v0.3.1 // indirect
-	github.com/karrick/godirwalk v1.14.0
+	github.com/karrick/godirwalk v1.16.1
 	github.com/otiai10/copy v1.0.2
-	github.com/pieterclaerhout/go-waitgroup v1.0.7
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.22.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/screwdriver-cd/store-cli
 
-go 1.12
+go 1.15
 
 require (
 	github.com/google/go-cmp v0.5.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/screwdriver-cd/store-cli
 go 1.12
 
 require (
-	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/karrick/godirwalk v1.16.1
 	github.com/otiai10/copy v1.0.2
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/screwdriver-cd/store-cli
 
-go 1.15
+go 1.12
 
 require (
 	github.com/google/go-cmp v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -35,6 +37,7 @@ github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/karrick/godirwalk v1.14.0 h1:FFk1V9N1Qke8Iv4o6uBQK8HJ6slYM3uSL8tPkiBH8+M=
-github.com/karrick/godirwalk v1.14.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
+github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
+github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
@@ -16,10 +16,8 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ry
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
-github.com/pieterclaerhout/go-waitgroup v1.0.7 h1:W9zHJzXO3SPo7Rb3E8hkk8D0gJPdP6DWENt6M08IxWE=
-github.com/pieterclaerhout/go-waitgroup v1.0.7/go.mod h1:TJIzZKRP4sc5AT8M0RVUwXhw/OWMxg/lW8VsQz4SRBo=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
@@ -35,7 +33,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,19 +9,19 @@ import (
 var logger = log.WithFields(log.Fields{"app": "store-cli"})
 
 const (
-	LOGLEVEL_ERROR = log.ErrorLevel
-	LOGLEVEL_WARN  = log.WarnLevel
-	LOGLEVEL_INFO  = log.InfoLevel
+	LoglevelError = log.ErrorLevel
+	LoglevelWarn  = log.WarnLevel
+	LoglevelInfo  = log.InfoLevel
 )
 
 const (
-	ERRTYPE_COPY         = "copy"
-	ERRTYPE_SCOPE        = "scope"
-	ERRTYPE_COMMAND      = "command"
-	ERRTYPE_FILE         = "file"
-	ERRTYPE_META         = "meta"
-	ERRTYPE_ZIP          = "zip"
-	ERRTYPE_MAXSIZELIMIT = "maxsizelimit"
+	ErrtypeCopy         = "copy"
+	ErrtypeScope        = "scope"
+	ErrtypeCommand      = "command"
+	ErrtypeFile         = "file"
+	ErrtypeMd5          = "md5"
+	ErrtypeZip          = "zip"
+	ErrtypeMaxsizelimit = "maxsizelimit"
 )
 
 func init() {

--- a/sdstore/cache2disk_test.go
+++ b/sdstore/cache2disk_test.go
@@ -108,7 +108,7 @@ func Test_SetCache_wCompress_File_CherryPick(t *testing.T) {
 			assert.Assert(t, Cache2Disk("set", cache[0], local, true, true, 0) == nil)
 			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -135,7 +135,7 @@ func Test_SetCache_wCompress_File(t *testing.T) {
 			assert.Assert(t, Cache2Disk("set", cache[0], local, true, true, 0) == nil)
 			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -162,7 +162,7 @@ func Test_SetCache_wCompress_RewriteFile_NODELTA(t *testing.T) {
 
 			// compress: true
 			assert.Assert(t, Cache2Disk("set", cache[0], local, true, true, 0) == nil)
-			info, _ = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			info, _ = os.Lstat(filepath.Join(cacheDir, filepath.Dir(local), fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
 		}
 	}
@@ -216,7 +216,7 @@ func Test_SetCache_File_CherryPick(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -243,7 +243,7 @@ func Test_SetCache_File(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -271,7 +271,7 @@ func Test_SetCache_RewriteFile_NODELTA(t *testing.T) {
 
 			// compress: true
 			assert.Assert(t, Cache2Disk("set", cache[0], local, false, true, 0) == nil)
-			info, _ = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".meta")))
+			info, _ = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, Md5Extension)))
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
 		}
 	}
@@ -298,7 +298,7 @@ func Test_SetCache_File_NoMETADATACheck(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, fmt.Sprintf("%s%s", local, Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -350,7 +350,7 @@ func Test_RemoveCache_File(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.ErrorContains(t, err, "no such file or directory")
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -377,7 +377,7 @@ func Test_SetCache_wCompress_NewFolder_CherryPick(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -407,7 +407,7 @@ func Test_GetCache_wCompress_Folder_CherryPick(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -434,7 +434,7 @@ func Test_SetCache_wCompress_NewFolder(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -460,7 +460,7 @@ func Test_SetCache_wCompress_RewriteFolder_NODELTA(t *testing.T) {
 			local, _ := filepath.Abs(eachFolder)
 			assert.Assert(t, Cache2Disk("set", cache[0], local, true, true, 0) == nil)
 
-			info, _ = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			info, _ = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
 		}
 	}
@@ -490,7 +490,7 @@ func Test_GetCache_wCompress_Folder(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -521,7 +521,7 @@ func Test_GetCache_wCompress_Folder_doNOTOverwriteNewFilesInLocal(t *testing.T) 
 			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 
 			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", "donotoverwrite", ".txt")))
@@ -552,7 +552,7 @@ func Test_RemoveCache_Folder_wCompress(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.ErrorContains(t, err, "no such file or directory")
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -579,7 +579,7 @@ func Test_SetCache_NewFolder(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -610,7 +610,7 @@ func Test_SetCache_RewriteFolder_NODELTA(t *testing.T) {
 			info, _ := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			fmt.Printf("currentTime: [%v], file: [%v], createTime: [%v]\n", currentTime, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat), info.ModTime().Unix())
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
-			info, _ = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			info, _ = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			fmt.Printf("currentTime: [%v], file: [%v], createTime: [%v]\n", currentTime, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat), info.ModTime().Unix())
 			assert.Assert(t, info.ModTime().Unix() < currentTime)
 		}
@@ -638,7 +638,7 @@ func Test_SetCache_NewFolder_NoMETADATACheck(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -665,7 +665,7 @@ func Test_GetCache_Folder(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -693,7 +693,7 @@ func Test_GetCache_Folder_doNOTOverwriteNewFilesInLocal(t *testing.T) {
 			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 
 			_, err = os.Lstat(filepath.Join(local, fmt.Sprintf("%s%s", "donotoverwrite", ".txt")))
@@ -724,7 +724,7 @@ func Test_RemoveCache_Folder(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".txt")))
 			assert.ErrorContains(t, err, "no such file or directory")
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.ErrorContains(t, err, "no such file or directory")
 		}
 	}
@@ -757,7 +757,7 @@ func Test_SetCache_NewFolder_wCompress_wTilde(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -790,7 +790,7 @@ func Test_SetCache_NewFolder_wTilde(t *testing.T) {
 			_, err := os.Lstat(filepath.Join(cacheDir, local, "testfolder1.txt"))
 			assert.Assert(t, err == nil)
 
-			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, local, fmt.Sprintf("%s%s", filepath.Base(local), Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}
@@ -864,7 +864,7 @@ func Test_SetCache_NewRelativeFolder_wCompress(t *testing.T) {
 
 			_, err = os.Lstat(filepath.Join(cacheDir, eachFolder, fmt.Sprintf("%s%s", filepath.Base(eachFolder), CompressFormat)))
 			assert.Assert(t, err == nil)
-			_, err = os.Lstat(filepath.Join(cacheDir, eachFolder, fmt.Sprintf("%s%s", filepath.Base(eachFolder), ".meta")))
+			_, err = os.Lstat(filepath.Join(cacheDir, eachFolder, fmt.Sprintf("%s%s", filepath.Base(eachFolder), Md5Extension)))
 			assert.Assert(t, err == nil)
 		}
 	}

--- a/sdstore/ziphelper.go
+++ b/sdstore/ziphelper.go
@@ -48,7 +48,7 @@ const ZiphelperModule = "ziphelper"
 func Zip(source, target string) error {
 	zipfile, err := os.Create(target)
 	if err != nil {
-		return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+		return logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 	}
 	defer zipfile.Close()
 
@@ -58,7 +58,7 @@ func Zip(source, target string) error {
 	sourceInfo, err := os.Stat(source)
 	if err != nil {
 		msg := fmt.Sprintf("%s: stat: %v", source, err)
-		return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
+		return logger.Log(logger.LoglevelError, ZiphelperModule, "", msg)
 	}
 
 	var baseDir string
@@ -69,19 +69,19 @@ func Zip(source, target string) error {
 	return filepath.Walk(source, func(fpath string, info os.FileInfo, err error) error {
 		if err != nil {
 			msg := fmt.Sprintf("walking to %s: %v", fpath, err)
-			return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, logger.ERRTYPE_FILE, msg)
+			return logger.Log(logger.LoglevelError, ZiphelperModule, logger.ErrtypeFile, msg)
 		}
 
 		header, err := zip.FileInfoHeader(info)
 		if err != nil {
 			msg := fmt.Sprintf("%s: getting header: %v", fpath, err)
-			return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
+			return logger.Log(logger.LoglevelError, ZiphelperModule, "", msg)
 		}
 
 		if baseDir != "" {
 			name, err := filepath.Rel(source, fpath)
 			if err != nil {
-				return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+				return logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 			}
 			header.Name = path.Join(baseDir, filepath.ToSlash(name))
 		}
@@ -101,7 +101,7 @@ func Zip(source, target string) error {
 		writer, err := w.CreateHeader(header)
 		if err != nil {
 			msg := fmt.Sprintf("%s: making header: %v", fpath, err)
-			return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
+			return logger.Log(logger.LoglevelError, ZiphelperModule, "", msg)
 		}
 
 		if info.IsDir() {
@@ -112,12 +112,12 @@ func Zip(source, target string) error {
 			linkTarget, err := os.Readlink(fpath)
 			if err != nil {
 				msg := fmt.Sprintf("%s: readlink: %v", fpath, err)
-				return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
+				return logger.Log(logger.LoglevelError, ZiphelperModule, "", msg)
 			}
 			_, err = writer.Write([]byte(filepath.ToSlash(linkTarget)))
 			if err != nil {
 				msg := fmt.Sprintf("%s: writing symlink target: %v", fpath, err)
-				return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
+				return logger.Log(logger.LoglevelError, ZiphelperModule, "", msg)
 			}
 			return nil
 		}
@@ -126,14 +126,14 @@ func Zip(source, target string) error {
 			file, err := os.Open(fpath)
 			if err != nil {
 				msg := fmt.Sprintf("%s: opening: %v", fpath, err)
-				return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
+				return logger.Log(logger.LoglevelError, ZiphelperModule, "", msg)
 			}
 			defer file.Close()
 
 			_, err = io.CopyN(writer, file, info.Size())
 			if err != nil && err != io.EOF {
 				msg := fmt.Sprintf("%s: copying contents: %v", fpath, err)
-				return logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
+				return logger.Log(logger.LoglevelError, ZiphelperModule, "", msg)
 			}
 		}
 
@@ -153,7 +153,7 @@ func Unzip(src string, dest string) ([]string, error) {
 
 	zr, err := zip.OpenReader(src)
 	if err != nil {
-		logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+		logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 		return files, err
 	}
 	defer zr.Close()
@@ -165,7 +165,7 @@ func Unzip(src string, dest string) ([]string, error) {
 
 			rc, err := file.Open()
 			if err != nil {
-				logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+				logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 				return fPath, fTime, err
 			}
 			defer rc.Close()
@@ -175,7 +175,7 @@ func Unzip(src string, dest string) ([]string, error) {
 			// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
 			if dest != "/" && !strings.HasPrefix(fPath, filepath.Clean(dest)+string(os.PathSeparator)) {
 				msg := fmt.Errorf("%s: illegal file path", fPath)
-				logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", msg)
+				logger.Log(logger.LoglevelError, ZiphelperModule, "", msg)
 
 				return fPath, fTime, msg
 			}
@@ -187,24 +187,24 @@ func Unzip(src string, dest string) ([]string, error) {
 				buffer := make([]byte, file.FileInfo().Size())
 				size, err := rc.Read(buffer)
 				if err != nil && err != io.EOF {
-					logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+					logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 					return fPath, fTime, err
 				}
 				target := string(buffer[:size])
 				err = os.Symlink(target, fPath)
 				if err != nil {
-					logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+					logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 					return fPath, fTime, err
 				}
 			} else {
 				if err = os.MkdirAll(filepath.Dir(fPath), os.ModePerm); err != nil {
-					logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+					logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 					return fPath, fTime, err
 				}
 
 				outFile, err := os.OpenFile(fPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
 				if err != nil {
-					logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+					logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 					return fPath, fTime, err
 				}
 				defer outFile.Close()
@@ -212,7 +212,7 @@ func Unzip(src string, dest string) ([]string, error) {
 				_, err = io.Copy(outFile, rc)
 
 				if err != nil {
-					logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+					logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 					return fPath, fTime, err
 				}
 				fTime = fileTime{fPath, file.Modified}
@@ -221,7 +221,7 @@ func Unzip(src string, dest string) ([]string, error) {
 		}(file)
 
 		if err != nil {
-			logger.Log(logger.LOGLEVEL_ERROR, ZiphelperModule, "", err)
+			logger.Log(logger.LoglevelError, ZiphelperModule, "", err)
 			return files, err
 		}
 		files = append(files, fPath)
@@ -236,7 +236,7 @@ func Unzip(src string, dest string) ([]string, error) {
 	for _, ft := range filesTime {
 		if err := os.Chtimes(ft.path, time.Now(), ft.modtime); err != nil {
 			msg := fmt.Sprintf("failed to update file timestamps: %v", err)
-			logger.Log(logger.LOGLEVEL_WARN, ZiphelperModule, "", msg)
+			logger.Log(logger.LoglevelWarn, ZiphelperModule, "", msg)
 		}
 	}
 

--- a/store-cli.go
+++ b/store-cli.go
@@ -17,9 +17,9 @@ import (
 
 // VERSION gets set by the build script via the LDFLAGS
 var VERSION string
-var CacheStrategy string = strings.ToLower(os.Getenv("SD_CACHE_STRATEGY"))
+var CacheStrategy = strings.ToLower(os.Getenv("SD_CACHE_STRATEGY"))
 var CacheCompress, _ = strconv.ParseBool(strings.ToLower(strings.TrimSpace(os.Getenv("SD_CACHE_COMPRESS"))))
-var CacheMetaDataCheck, _ = strconv.ParseBool(strings.ToLower(strings.TrimSpace(os.Getenv("SD_CACHE_MD5CHECK"))))
+var CacheMd5Check, _ = strconv.ParseBool(strings.ToLower(strings.TrimSpace(os.Getenv("SD_CACHE_MD5CHECK"))))
 var CacheMaxSizeInMB, _ = strconv.ParseInt(os.Getenv("SD_CACHE_MAX_SIZE_MB"), 0, 64)
 
 // successExit exits process with 0
@@ -30,7 +30,7 @@ func successExit() {
 // failureExit exits process with 1
 func failureExit(err error) {
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 	}
 	os.Exit(1)
 }
@@ -39,8 +39,8 @@ func failureExit(err error) {
 // This should only happen if the previous recovery caused a panic.
 func finalRecover() {
 	if p := recover(); p != nil {
-		fmt.Fprintln(os.Stderr, "ERROR: Something terrible has happened. Please file a ticket with this info:")
-		fmt.Fprintf(os.Stderr, "ERROR: %v\n%s\n", p, string(debug.Stack()))
+		_, _ = fmt.Fprintln(os.Stderr, "ERROR: Something terrible has happened. Please file a ticket with this info:")
+		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %v\n%s\n", p, string(debug.Stack()))
 		failureExit(nil)
 	}
 	successExit()
@@ -107,7 +107,7 @@ func makeURL(storeType, scope, key string) (*url.URL, error) {
 	}
 
 	if len(path) == 0 {
-		return nil, fmt.Errorf("Invalid parameters")
+		return nil, fmt.Errorf("invalid parameters")
 	}
 
 	fullpath := fmt.Sprintf("%s%s", storeURL, path)
@@ -121,7 +121,7 @@ func get(storeType, scope, key string) error {
 	}
 
 	if strings.ToLower(storeType) == "cache" && CacheStrategy == "disk" {
-		return sdstore.Cache2Disk("get", scope, key, CacheCompress, CacheMetaDataCheck, CacheMaxSizeInMB)
+		return sdstore.Cache2Disk("get", scope, key, CacheCompress, CacheMd5Check, CacheMaxSizeInMB)
 	} else {
 		sdToken := os.Getenv("SD_TOKEN")
 		fullURL, err := makeURL(storeType, scope, key)
@@ -151,7 +151,7 @@ func set(storeType, scope, filePath string) error {
 	}
 
 	if strings.ToLower(storeType) == "cache" && CacheStrategy == "disk" {
-		return sdstore.Cache2Disk("set", scope, filePath, CacheCompress, CacheMetaDataCheck, CacheMaxSizeInMB)
+		return sdstore.Cache2Disk("set", scope, filePath, CacheCompress, CacheMd5Check, CacheMaxSizeInMB)
 	} else {
 		sdToken := os.Getenv("SD_TOKEN")
 		fullURL, err := makeURL(storeType, scope, filePath)
@@ -180,7 +180,7 @@ func remove(storeType, scope, key string) error {
 	}
 
 	if strings.ToLower(storeType) == "cache" && CacheStrategy == "disk" {
-		return sdstore.Cache2Disk("remove", scope, key, CacheCompress, CacheMetaDataCheck, CacheMaxSizeInMB)
+		return sdstore.Cache2Disk("remove", scope, key, CacheCompress, CacheMd5Check, CacheMaxSizeInMB)
 	} else {
 		sdToken := os.Getenv("SD_TOKEN")
 		store := sdstore.NewStore(sdToken)
@@ -193,7 +193,7 @@ func remove(storeType, scope, key string) error {
 
 			err = store.Remove(md5URL)
 			if err != nil {
-				return fmt.Errorf("Failed to remove file from %s: %s", md5URL.String(), err)
+				return fmt.Errorf("failed to remove file from %s: %s", md5URL.String(), err)
 			}
 
 			zipURL, err := makeURL(storeType, scope, fmt.Sprintf("%s%s", filepath.Clean(key), ".zip"))
@@ -203,7 +203,7 @@ func remove(storeType, scope, key string) error {
 
 			err = store.Remove(zipURL)
 			if err != nil {
-				return fmt.Errorf("Failed to remove file from %s: %s", zipURL.String(), err)
+				return fmt.Errorf("failed to remove file from %s: %s", zipURL.String(), err)
 			}
 
 			return nil
@@ -302,5 +302,5 @@ func main() {
 		},
 	}
 
-	app.Run(os.Args)
+	_ = app.Run(os.Args)
 }


### PR DESCRIPTION
## Context

Storing the meta file consumes space and time.

## Objective

Convert the metadata to md5 and compare md5. Fix log messages and variable naming standards.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2348

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
