### PR TITLE
fix(2348): cache performance enhancements

### DIFF
--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -358,7 +358,7 @@ func setCache(src, dest, command string, compress, md5Check bool, cacheMaxSizeIn
 
 	if md5Check {
 		md5Path = filepath.Join(destPath, fmt.Sprintf("%s%s", destBase, Md5Extension))
-		md5File, err = os.OpenFile(md5Path, os.O_CREATE|os.O_WRONLY, 0777)
+		md5File, err = os.OpenFile(md5Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
 		if err != nil {
 			_ = logger.Log(logger.LoglevelWarn, "", logger.ErrtypeMd5, fmt.Sprintf("not able to create %v file", md5Path))
 		} else {


### PR DESCRIPTION
## Objective

As part of the backward compatibility test, the md5 file is not overwritten. Adding flags to overwrite md5 file.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2348
https://github.com/screwdriver-cd/store-cli/pull/70

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
