### PR TITLE
fix(2348): add compression level

### DIFF
--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -21,6 +21,7 @@ import (
 const CompressFormatTarZst = ".tar.zst"
 const CompressFormatZip = ".zip"
 const Md5Extension = ".md5"
+const TarCompressionLevel = "-3"			//	default compression level - 3 / possible values (1-19) or --fast
 
 type FileInfo struct {
 	Path    string `json:"path"`
@@ -338,7 +339,7 @@ func setCache(src, dest, command string, compress, md5Check bool, cacheMaxSizeIn
 			return logger.Log(logger.LoglevelError, "", logger.ErrtypeZip, err)
 		}
 		_ = os.MkdirAll(destPath, 0777)
-		cmd := fmt.Sprintf("cd %s && tar -c %s | %s -T0 --fast > %s || true; cd %s", srcPath, srcFile, getZstdBinary(), targetPath, cwd)
+		cmd := fmt.Sprintf("cd %s && tar -c %s | %s -T0 %s > %s || true; cd %s", srcPath, srcFile, getZstdBinary(), TarCompressionLevel, targetPath, cwd)
 		err = ExecuteCommand(cmd)
 		if err != nil {
 			msg = fmt.Sprintf("failed to compress files from %v", src)

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -21,7 +21,7 @@ import (
 const CompressFormatTarZst = ".tar.zst"
 const CompressFormatZip = ".zip"
 const Md5Extension = ".md5"
-const TarCompressionLevel = "-3" //	default compression level - 3 / possible values (1-19) or --fast
+const CompressionLevel = "-3" //	default compression level - 3 / possible values (1-19) or --fast
 
 type FileInfo struct {
 	Path    string `json:"path"`
@@ -339,7 +339,7 @@ func setCache(src, dest, command string, compress, md5Check bool, cacheMaxSizeIn
 			return logger.Log(logger.LoglevelError, "", logger.ErrtypeZip, err)
 		}
 		_ = os.MkdirAll(destPath, 0777)
-		cmd := fmt.Sprintf("cd %s && tar -c %s | %s -T0 %s > %s || true; cd %s", srcPath, srcFile, getZstdBinary(), TarCompressionLevel, targetPath, cwd)
+		cmd := fmt.Sprintf("cd %s && tar -c %s | %s -T0 %s > %s || true; cd %s", srcPath, srcFile, getZstdBinary(), CompressionLevel, targetPath, cwd)
 		err = ExecuteCommand(cmd)
 		if err != nil {
 			msg = fmt.Sprintf("failed to compress files from %v", src)

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -21,7 +21,7 @@ import (
 const CompressFormatTarZst = ".tar.zst"
 const CompressFormatZip = ".zip"
 const Md5Extension = ".md5"
-const TarCompressionLevel = "-3"			//	default compression level - 3 / possible values (1-19) or --fast
+const TarCompressionLevel = "-3" //	default compression level - 3 / possible values (1-19) or --fast
 
 type FileInfo struct {
 	Path    string `json:"path"`

--- a/sdstore/cache2disk.go
+++ b/sdstore/cache2disk.go
@@ -44,15 +44,15 @@ func ExecuteCommand(command string) error {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil || strings.TrimSpace(stderr.String()) != "" {
-		return logger.Log(logger.LoglevelError, "", "", fmt.Sprintf("run err: %v, command err: %v, command out: %v", err, stderr.String(), stdout.String()))
+		return logger.Log(logger.LoglevelError, "", "", fmt.Sprintf("error: %v, %v, out: %v", err, stderr.String(), stdout.String()))
 	}
 	_ = logger.Log(logger.LoglevelInfo, "", stdout.String())
 	return nil
 }
 
 // ZStandard from https://github.com/facebook/zstd
-// To test in mac locally - download from https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-macosx.tar.gz and set path
-// To test in linux locally - download from https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-linux.tar.gz and set path
+// To test in mac - download from https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-macosx.tar.gz and set path
+// To test in linux - download from https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-linux.tar.gz and set path
 func getZstdBinary() string {
 	switch runtime.GOOS {
 	case "darwin":
@@ -343,7 +343,7 @@ func setCache(src, dest, command string, compress, md5Check bool, cacheMaxSizeIn
 		err = ExecuteCommand(cmd)
 		if err != nil {
 			msg = fmt.Sprintf("failed to compress files from %v", src)
-			return logger.Log(logger.LoglevelError, "", logger.ErrtypeZip, msg)
+			_ = logger.Log(logger.LoglevelWarn, "", logger.ErrtypeZip, msg)
 		}
 		_ = os.Chmod(targetPath, 0777)
 		_ = os.Chmod(destPath, 0777)


### PR DESCRIPTION
## Objective

add compression level. set to default compression level. This saves disk space and speed is on par with --fast compression level.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2348

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
