### PR TITLE
feat: set http timeout to 60 secs

### DIFF
--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -22,7 +22,7 @@ const retryWaitMin = 100
 const retryWaitMax = 300
 
 var maxRetries = 5
-var httpTimeout = time.Duration(20) * time.Second
+var httpTimeout = time.Duration(60) * time.Second
 var UTCLoc, _ = time.LoadLocation("UTC")
 
 // SDStore is able to upload, download, and remove the contents of a Reader to the SD Store


### PR DESCRIPTION
## Context

Http client timeout is too low for the majority of requests with larger upload size

## Objective

This PR changes HTTP timeout value to 60 seconds

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
