### PR TITLE
feat: make httpTimeout configurable per operation

### DIFF
--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -18,11 +18,6 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-const retryWaitMin = 100
-const retryWaitMax = 300
-
-var maxRetries = 5
-var httpTimeout = time.Duration(60) * time.Second
 var UTCLoc, _ = time.LoadLocation("UTC")
 
 // SDStore is able to upload, download, and remove the contents of a Reader to the SD Store
@@ -38,13 +33,13 @@ type sdStore struct {
 }
 
 // NewStore returns an SDStore instance.
-func NewStore(token string) SDStore {
+func NewStore(token string, maxRetries int, httpTimeout int, retryWaitMin int, retryWaitMax int) SDStore {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = maxRetries
 	retryClient.RetryWaitMin = time.Duration(retryWaitMin) * time.Millisecond
 	retryClient.RetryWaitMax = time.Duration(retryWaitMax) * time.Millisecond
 	retryClient.Backoff = retryablehttp.LinearJitterBackoff
-	retryClient.HTTPClient.Timeout = httpTimeout
+	retryClient.HTTPClient.Timeout = time.Duration(httpTimeout) * time.Second
 	retryClient.CheckRetry = retryablehttp.DefaultRetryPolicy
 
 	return &sdStore{


### PR DESCRIPTION
## Context

HttpTimeout for store-cli operations needs to be configurable individually for Upload/Download operations

## Objective

This PR adds configurable values for `httpTimeout`, `retryWaitMin`,`retryWaitMax` and `maxRetries` for each operation

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
