### PR TITLE
feat(3013): Add Expect Header When Uploading File

### DIFF
--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -359,6 +359,7 @@ func (s *sdStore) putFile(url *url.URL, bodyType string, filePath string) error 
 
 	req.Header.Set("Authorization", tokenHeader(s.token))
 	req.Header.Set("Content-Type", bodyType)
+	req.Header.Set("Expect", "100-continue")
 	if fi, err := os.Stat(filePath); err == nil {
 		req.ContentLength = fi.Size()
 	}

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -42,6 +42,11 @@ func NewStore(token string, maxRetries int, httpTimeout int, retryWaitMin int, r
 	retryClient.HTTPClient.Timeout = time.Duration(httpTimeout) * time.Second
 	retryClient.CheckRetry = retryablehttp.DefaultRetryPolicy
 
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.ExpectContinueTimeout = 5 * time.Second
+
+	retryClient.HTTPClient.Transport = customTransport
+
 	return &sdStore{
 		token:  token,
 		client: retryClient,

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -172,6 +172,10 @@ func TestUpload(t *testing.T) {
 			if r.ContentLength != fsize {
 				t.Errorf("Wrong Content-Length sent to uploader. Got %d, want %d", r.ContentLength, fsize)
 			}
+
+			if r.Header.Get("Expect") != "100-continue" {
+				t.Errorf("Expected 'Expect: 100-continue' header, but got %v", r.Header.Get("Expect"))
+			}
 		} else if r.Method == "GET" {
 		}
 	})

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -176,6 +176,7 @@ func TestUpload(t *testing.T) {
 			if r.Header.Get("Expect") != "100-continue" {
 				t.Errorf("Expected 'Expect: 100-continue' header, but got %v", r.Header.Get("Expect"))
 			}
+
 		} else if r.Method == "GET" {
 		}
 	})
@@ -240,6 +241,10 @@ func TestUploadZipWithChange(t *testing.T) {
 			fsize := stat.Size()
 			if r.ContentLength != fsize {
 				t.Errorf("Wrong Content-Length sent to uploader. Got %d, want %d", r.ContentLength, fsize)
+			}
+
+			if r.Header.Get("Expect") != "100-continue" {
+				t.Errorf("Expected 'Expect: 100-continue' header, but got %v", r.Header.Get("Expect"))
 			}
 
 			err = os.Remove(zipfile)


### PR DESCRIPTION
## Context

I would like to reduce unnecessary retries when uploading large files.
By using the `Expect: 100-continue` header, the content length can be checked before the body is uploaded.
Thus, the HTTP client (store-cli) can receive a 413 error earlier without unnecessary retries.

I have also submitted a related PR to store.

https://github.com/screwdriver-cd/store/pull/146

## Objective

To reduce unnecessary retries, return a 413 error earlier.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

[issue](https://github.com/screwdriver-cd/screwdriver/issues/3013)
[store](https://github.com/screwdriver-cd/store/pull/146)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
