### PR TITLE
fix(3013): Make Expect Header and Timeout Configurable to Prevent Unnecessary Upload Delays

### DIFF
--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -63,7 +63,6 @@ func NewStore(token string, maxRetries int, httpTimeout int, retryWaitMin int, r
 
 	expectContinueTimeout := time.Duration(getExpectContinueTimeout())
 	customTransport.ExpectContinueTimeout = expectContinueTimeout * time.Second
-	customTransport.ForceAttemptHTTP2 = false
 
 	retryClient.HTTPClient.Transport = customTransport
 

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -33,6 +33,8 @@ type sdStore struct {
 	client *retryablehttp.Client
 }
 
+// getExpectContinueTimeout checks the CD_EXPECT_CONTINUE_TIMEOUT environment variable.
+// It returns the timeout. If the variable is not set, invalid, or negative, it defaults to 1 sec.
 func getExpectContinueTimeout() int {
 	envValue := os.Getenv("CD_EXPECT_CONTINUE_TIMEOUT")
 

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -33,10 +33,10 @@ type sdStore struct {
 	client *retryablehttp.Client
 }
 
-// getExpectContinueTimeout checks the CD_EXPECT_CONTINUE_TIMEOUT environment variable.
+// getExpectContinueTimeout checks the SD_EXPECT_CONTINUE_TIMEOUT environment variable.
 // It returns the timeout. If the variable is not set, invalid, or negative, it defaults to 1 sec.
 func getExpectContinueTimeout() int {
-	envValue := os.Getenv("CD_EXPECT_CONTINUE_TIMEOUT")
+	envValue := os.Getenv("SD_EXPECT_CONTINUE_TIMEOUT")
 
 	if envValue == "" {
 		// default 1 sec

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -63,6 +63,7 @@ func NewStore(token string, maxRetries int, httpTimeout int, retryWaitMin int, r
 
 	expectContinueTimeout := time.Duration(getExpectContinueTimeout())
 	customTransport.ExpectContinueTimeout = expectContinueTimeout * time.Second
+	customTransport.ForceAttemptHTTP2 = false
 
 	retryClient.HTTPClient.Transport = customTransport
 

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -34,7 +34,7 @@ type sdStore struct {
 }
 
 func getExpectContinueTimeout() int {
-	envValue := os.Getenv("EXPECT_CONTINUE_TIMEOUT")
+	envValue := os.Getenv("CD_EXPECT_CONTINUE_TIMEOUT")
 
 	if envValue == "" {
 		// default 1 sec

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -43,12 +43,12 @@ func getExpectContinueTimeout() int {
 		return 1
 	}
 
-	expectcontinuetimeout, err := strconv.Atoi(envValue)
-	if err != nil || expectcontinuetimeout < 0 {
+	expectContinueTimeout, err := strconv.Atoi(envValue)
+	if err != nil || expectContinueTimeout < 0 {
 		return 1
 	}
 
-	return expectcontinuetimeout
+	return expectContinueTimeout
 }
 
 // NewStore returns an SDStore instance.

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -610,27 +610,3 @@ func TestGetExpectContinueTimeout(t *testing.T) {
 
 	os.Unsetenv("CD_EXPECT_CONTINUE_TIMEOUT")
 }
-
-func TestNewStore_ForceAttemptHTTP2(t *testing.T) {
-	token := "test-token"
-	maxRetries := 3
-	httpTimeout := 10
-	retryWaitMin := 100
-	retryWaitMax := 200
-
-	store := NewStore(token, maxRetries, httpTimeout, retryWaitMin, retryWaitMax)
-
-	retryClient, ok := store.(*sdStore)
-	if !ok {
-		t.Errorf("Unable to get *sdStore")
-	}
-
-	transport, ok := retryClient.client.HTTPClient.Transport.(*http.Transport)
-	if !ok {
-		t.Errorf("Unable to get *http.Transport")
-	}
-
-	if transport.ForceAttemptHTTP2 != false {
-		t.Errorf("expected ForceAttemptHTTP2 to be false, got %v", transport.ForceAttemptHTTP2)
-	}
-}

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -610,3 +610,27 @@ func TestGetExpectContinueTimeout(t *testing.T) {
 
 	os.Unsetenv("EXPECT_CONTINUE_TIMEOUT")
 }
+
+func TestNewStore_ForceAttemptHTTP2(t *testing.T) {
+	token := "test-token"
+	maxRetries := 3
+	httpTimeout := 10
+	retryWaitMin := 100
+	retryWaitMax := 200
+
+	store := NewStore(token, maxRetries, httpTimeout, retryWaitMin, retryWaitMax)
+
+	retryClient, ok := store.(*sdStore)
+	if !ok {
+		t.Errorf("Unable to get *sdStore")
+	}
+
+	transport, ok := retryClient.client.HTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Errorf("Unable to get *http.Transport")
+	}
+
+	if transport.ForceAttemptHTTP2 != false {
+		t.Errorf("expected ForceAttemptHTTP2 to be false, got %v", transport.ForceAttemptHTTP2)
+	}
+}

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -598,7 +598,7 @@ func TestGetExpectContinueTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("env:"+tt.envValue, func(t *testing.T) {
-			os.Setenv("EXPECT_CONTINUE_TIMEOUT", tt.envValue)
+			os.Setenv("CD_EXPECT_CONTINUE_TIMEOUT", tt.envValue)
 
 			result := getExpectContinueTimeout()
 
@@ -608,7 +608,7 @@ func TestGetExpectContinueTimeout(t *testing.T) {
 		})
 	}
 
-	os.Unsetenv("EXPECT_CONTINUE_TIMEOUT")
+	os.Unsetenv("CD_EXPECT_CONTINUE_TIMEOUT")
 }
 
 func TestNewStore_ForceAttemptHTTP2(t *testing.T) {

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -583,3 +583,30 @@ func TestZipAndUnzipWithSymlink(t *testing.T) {
 	os.RemoveAll("../data/test")
 	os.RemoveAll("../data/testsymlink.zip")
 }
+
+func TestGetExpectContinueTimeout(t *testing.T) {
+	tests := []struct {
+		envValue string
+		expected int
+	}{
+		{"", 1},
+		{"5", 5},
+		{"0", 0},
+		{"-1", 1},
+		{"invalid", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run("env:"+tt.envValue, func(t *testing.T) {
+			os.Setenv("EXPECT_CONTINUE_TIMEOUT", tt.envValue)
+
+			result := getExpectContinueTimeout()
+
+			if result != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+
+	os.Unsetenv("EXPECT_CONTINUE_TIMEOUT")
+}

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -181,7 +181,7 @@ func TestUpload(t *testing.T) {
 		}
 	})
 	uploader.client.HTTPClient = http
-	uploader.Upload(u, testFile().Name(), false)
+	uploader.Upload(u, testFile().Name(), false, true)
 
 	if !called {
 		t.Fatalf("The HTTP client was never used.")
@@ -270,7 +270,7 @@ func TestUploadZipWithChange(t *testing.T) {
 	})
 
 	uploader.client.HTTPClient = http
-	uploader.Upload(u, testFile().Name(), true)
+	uploader.Upload(u, testFile().Name(), true, true)
 
 	if !getMd5 {
 		t.Errorf("Did not get md5 file")
@@ -314,7 +314,7 @@ func TestUploadZipNoChange(t *testing.T) {
 	})
 
 	uploader.client.HTTPClient = http
-	uploader.Upload(u, testFile2().Name(), true)
+	uploader.Upload(u, testFile2().Name(), true, true)
 
 	if called != 1 { // 1 GET
 		t.Fatalf("The HTTP client was not called as expected")
@@ -330,7 +330,7 @@ func TestUploadRetry(t *testing.T) {
 		atomic.AddInt32(&callCount, 1)
 	})
 	uploader.client.HTTPClient = http
-	err := uploader.Upload(u, testFile().Name(), false)
+	err := uploader.Upload(u, testFile().Name(), false, true)
 	if err == nil {
 		t.Error("Expected error from uploader.Upload(), got nil")
 	}
@@ -348,7 +348,7 @@ func TestUploadZipRetry(t *testing.T) {
 		atomic.AddInt32(&callCount, 1)
 	})
 	uploader.client.HTTPClient = http
-	err := uploader.Upload(u, testFile().Name(), true)
+	err := uploader.Upload(u, testFile().Name(), true, true)
 	if err == nil {
 		t.Error("Expected error from uploader.Upload(), got nil")
 	}
@@ -356,6 +356,32 @@ func TestUploadZipRetry(t *testing.T) {
 		t.Errorf("Expected 6 retries, got %d", callCount)
 	}
 	os.Remove("emitterdata_md5.json")
+}
+
+func TestUploadNotCache(t *testing.T) {
+	u, _ := url.Parse("http://fakestore.example.com/builds/1234-test")
+	uploader := newStore(2)
+	called := false
+
+	http := makeFakeHTTPClient(t, 200, "OK", func(r *http.Request) {
+		if r.Method == "PUT" {
+			called = true
+			got := bytes.NewBuffer(nil)
+			io.Copy(got, r.Body)
+			r.Body.Close()
+
+			if r.Header.Get("Expect") != "" {
+				t.Errorf("Unexpected 'Expect header' found")
+			}
+
+		}
+	})
+	uploader.client.HTTPClient = http
+	uploader.Upload(u, testFile().Name(), false, false)
+
+	if !called {
+		t.Fatalf("The HTTP client was never used.")
+	}
 }
 
 func TestDownloadZip(t *testing.T) {

--- a/sdstore/sdstore_test.go
+++ b/sdstore/sdstore_test.go
@@ -598,7 +598,7 @@ func TestGetExpectContinueTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("env:"+tt.envValue, func(t *testing.T) {
-			os.Setenv("CD_EXPECT_CONTINUE_TIMEOUT", tt.envValue)
+			os.Setenv("SD_EXPECT_CONTINUE_TIMEOUT", tt.envValue)
 
 			result := getExpectContinueTimeout()
 
@@ -608,5 +608,5 @@ func TestGetExpectContinueTimeout(t *testing.T) {
 		})
 	}
 
-	os.Unsetenv("CD_EXPECT_CONTINUE_TIMEOUT")
+	os.Unsetenv("SD_EXPECT_CONTINUE_TIMEOUT")
 }

--- a/store-cli.go
+++ b/store-cli.go
@@ -169,14 +169,17 @@ func set(storeType, scope, filePath string, timeout int) error {
 		store := sdstore.NewStore(sdToken, MAX_RETRIES, timeout, RETRY_WAIT_MIN, RETRY_WAIT_MAX)
 
 		var toCompress bool
+		var useExpectHeader bool
 
 		if storeType == "cache" {
 			toCompress = true
+			useExpectHeader = true
 		} else {
 			toCompress = false
+			useExpectHeader = false
 		}
 
-		return store.Upload(fullURL, filePath, toCompress)
+		return store.Upload(fullURL, filePath, toCompress, useExpectHeader)
 	}
 
 }

--- a/store-cli.go
+++ b/store-cli.go
@@ -42,6 +42,8 @@ func failureExit(err error) {
 	os.Exit(1)
 }
 
+// IsEnableExpectHeader checks the SD_ENABLE_EXPECT_HEADER environment variable.
+// It returns true if the variable is set to "true", otherwise it returns false.
 func IsEnableExpectHeader() bool {
 	var getEnableExpectHeader = os.Getenv("SD_ENABLE_EXPECT_HEADER")
 	return getEnableExpectHeader == "true"

--- a/store-cli.go
+++ b/store-cli.go
@@ -42,6 +42,11 @@ func failureExit(err error) {
 	os.Exit(1)
 }
 
+func IsEnableExpectHeader() bool {
+	var getEnableExpectHeader = os.Getenv("SD_ENABLE_EXPECT_HEADER")
+	return getEnableExpectHeader == "true"
+}
+
 // finalRecover makes one last attempt to recover from a panic.
 // This should only happen if the previous recovery caused a panic.
 func finalRecover() {
@@ -169,14 +174,15 @@ func set(storeType, scope, filePath string, timeout int) error {
 		store := sdstore.NewStore(sdToken, MAX_RETRIES, timeout, RETRY_WAIT_MIN, RETRY_WAIT_MAX)
 
 		var toCompress bool
-		var useExpectHeader bool
+		var useExpectHeader bool = false
 
 		if storeType == "cache" {
 			toCompress = true
-			useExpectHeader = true
+			if IsEnableExpectHeader() {
+				useExpectHeader = true
+			}
 		} else {
 			toCompress = false
-			useExpectHeader = false
 		}
 
 		return store.Upload(fullURL, filePath, toCompress, useExpectHeader)

--- a/store-cli_test.go
+++ b/store-cli_test.go
@@ -224,3 +224,30 @@ func TestGetTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEnableExpectHeader(t *testing.T) {
+	tests := []struct {
+		envValue string
+		expected bool
+	}{
+		{"true", true},
+		{"false", false},
+		{"1", false},
+		{"invalid", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run("env:"+tt.envValue, func(t *testing.T) {
+			os.Setenv("SD_ENABLE_EXPECT_HEADER", tt.envValue)
+
+			result := IsEnableExpectHeader()
+
+			if result != tt.expected {
+				t.Errorf("expected %t, got %t", tt.expected, result)
+			}
+		})
+	}
+
+	os.Unsetenv("SD_ENABLE_EXPECT_HEADER")
+}


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In a previous [PR](https://github.com/screwdriver-cd/store-cli/pull/82), the Expect header was being added in all cases, which led to unnecessary timeouts. Therefore, I have made it possible to configure whether to include the Expect header via an environment variable (default false). Additionally, the value of the ExpectContinueTimeout can also be configured through an environment variable.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
I fixed the unnecessary timeouts that occurred when uploading caches or artifacts.

Before the fix (It needs 5 sec before uploading.)
https://cd.screwdriver.cd/pipelines/15546/builds/967343/steps/sd-teardown-screwdriver-artifact-bookend

After the fix (Not taking long.)
https://cd.screwdriver.cd/pipelines/15546/builds/967342/steps/sd-teardown-screwdriver-artifact-bookend

## References

https://github.com/screwdriver-cd/launcher/pull/482

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
