### PR TITLE
fix: disable cgo dependencies

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,7 +13,7 @@ jobs:
             - gofmt: ret=$(find . -name '*.go' | xargs gofmt -d) && echo "$ret" && test -z "$ret"
             - test-setup: go install gotest.tools/gotestsum@latest
             - test: gotestsum --format testname --jsonfile ${SD_ARTIFACTS_DIR}/report.json -- -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out ./...
-            - build: go build -a -o store-cli
+            - build: CGO_ENABLED=0 go build -a -o store-cli
             - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
 
     deploy:


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Updating the Go version causes GLIBC version errors in images such as Rocky8.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Avoiding the use of cgo ensures that the build image remains unaffected.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
