### PR TITLE
Fix: Set Expect header for all store types

### DIFF
--- a/store-cli.go
+++ b/store-cli.go
@@ -176,16 +176,14 @@ func set(storeType, scope, filePath string, timeout int) error {
 		store := sdstore.NewStore(sdToken, MAX_RETRIES, timeout, RETRY_WAIT_MIN, RETRY_WAIT_MAX)
 
 		var toCompress bool
-		var useExpectHeader bool = false
-
 		if storeType == "cache" {
 			toCompress = true
-			if IsEnableExpectHeader() {
-				useExpectHeader = true
-			}
 		} else {
 			toCompress = false
 		}
+
+		// add Expect header if SD_ENABLE_EXPECT_HEADER=="true"
+		useExpectHeader := IsEnableExpectHeader()
 
 		return store.Upload(fullURL, filePath, toCompress, useExpectHeader)
 	}
@@ -257,10 +255,9 @@ func main() {
 
 	app := cli.NewApp()
 	app.Name = "store-cli"
-	app.Usage = "CLI to communicate with Screwdriver Store"
+	app.Usage = "CLI to get, set or remove items in the Screwdriver store"
 	app.UsageText = "[options]"
 	app.Copyright = "(c) 2018 Yahoo Inc."
-	app.Usage = "get, set or remove items in the Screwdriver store"
 	app.Version = VERSION
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
## Context

The 'Expect: 100-continue' header is conditionally added to large file upload requests. This enables a fail-fast mechanism where the server can immediately check request validity (e.g., file size limits) before the client sends the full body, thus preventing unnecessary data transfer.

This feature is currently only activated when the environment variable `SD_ENABLE_EXPECT_HEADER` is set and only applies to the `cache` store type.

## Objective

Add Expect header to all store types as long as `SD_ENABLE_EXPECT_HEADER` is set to "true". 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

