### PR TITLE
increase upload timeout

### DIFF
--- a/store-cli.go
+++ b/store-cli.go
@@ -25,7 +25,7 @@ var RETRY_WAIT_MIN = 100 // ms
 var RETRY_WAIT_MAX = 300 // ms
 
 // default http timeout for Upload/Download/Remove operations
-var UPLOAD_HTTP_TIMEOUT = 60    // seconds
+var UPLOAD_HTTP_TIMEOUT = 150   // seconds
 var DOWNLOAD_HTTP_TIMEOUT = 300 // seconds
 var REMOVE_HTTP_TIMEOUT = 300   // seconds
 

--- a/store-cli_test.go
+++ b/store-cli_test.go
@@ -134,7 +134,7 @@ func TestGetTimeout(t *testing.T) {
 			flagTimeout:    "",
 			envName:        "SD_STORE_CLI_UPLOAD_HTTP_TIMEOUT",
 			defaultTimeout: UPLOAD_HTTP_TIMEOUT,
-			expected:       60,
+			expected:       150,
 			envValue:       "",
 			shouldError:    false,
 		},


### PR DESCRIPTION
## Context

60s is relatively low for window with high build traffic

## Objective

increase timeout from 60s to 150s

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
