### PR TITLE
Feat/cache size display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ data/cache/
 
 # IDE
 .idea/
+.vscode/

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -35,31 +35,6 @@ func formatBytes(bytes int64) string {
 	return fmt.Sprintf("%.2f GB", float64(bytes)/(1024*1024*1024))
 }
 
-// estimateTransferTime estimates transfer time based on size and assumed speed
-// Default speeds: 10 MB/s for download, 5 MB/s for upload
-func estimateTransferTime(bytes int64, isUpload bool) string {
-	var speedMBps float64 = 10.0 // download speed
-	if isUpload {
-		speedMBps = 5.0 // upload speed
-	}
-
-	if bytes == 0 {
-		return "< 1s"
-	}
-
-	sizeMB := float64(bytes) / (1024 * 1024)
-	seconds := sizeMB / speedMBps
-
-	if seconds < 1 {
-		return "< 1s"
-	}
-	if seconds < 60 {
-		return fmt.Sprintf("~%.0fs", seconds)
-	}
-	minutes := seconds / 60
-	return fmt.Sprintf("~%.1fm", minutes)
-}
-
 // SDStore is able to upload, download, and remove the contents of a Reader to the SD Store
 type SDStore interface {
 	Upload(u *url.URL, filePath string, toCompress bool, useExpectHeader bool) error
@@ -391,7 +366,7 @@ func (s *sdStore) request(url string, requestType string) ([]byte, error) {
 	// For GET requests, display file size and estimated download time
 	if requestType == "GET" && res.StatusCode/100 == 2 {
 		if contentLength := res.ContentLength; contentLength > 0 {
-			log.Printf("Downloading: %s (estimated time: %s)", formatBytes(contentLength), estimateTransferTime(contentLength, false))
+			log.Printf("Downloading: %s ", formatBytes(contentLength))
 		}
 	}
 
@@ -448,7 +423,7 @@ func (s *sdStore) putFile(url *url.URL, bodyType string, filePath string, useExp
 		req.ContentLength = fi.Size()
 		fileSize = fi.Size()
 		// Display file size and estimated upload time
-		log.Printf("Uploading: %s (estimated time: %s)", formatBytes(fileSize), estimateTransferTime(fileSize, true))
+		log.Printf("Uploading: %s", formatBytes(fileSize))
 	}
 
 	startTime := time.Now()

--- a/sdstore/sdstore.go
+++ b/sdstore/sdstore.go
@@ -21,6 +21,45 @@ import (
 
 var UTCLoc, _ = time.LoadLocation("UTC")
 
+// formatBytes converts bytes to human-readable format
+func formatBytes(bytes int64) string {
+	if bytes < 1024 {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	if bytes < 1024*1024 {
+		return fmt.Sprintf("%.2f KB", float64(bytes)/1024)
+	}
+	if bytes < 1024*1024*1024 {
+		return fmt.Sprintf("%.2f MB", float64(bytes)/(1024*1024))
+	}
+	return fmt.Sprintf("%.2f GB", float64(bytes)/(1024*1024*1024))
+}
+
+// estimateTransferTime estimates transfer time based on size and assumed speed
+// Default speeds: 10 MB/s for download, 5 MB/s for upload
+func estimateTransferTime(bytes int64, isUpload bool) string {
+	var speedMBps float64 = 10.0 // download speed
+	if isUpload {
+		speedMBps = 5.0 // upload speed
+	}
+
+	if bytes == 0 {
+		return "< 1s"
+	}
+
+	sizeMB := float64(bytes) / (1024 * 1024)
+	seconds := sizeMB / speedMBps
+
+	if seconds < 1 {
+		return "< 1s"
+	}
+	if seconds < 60 {
+		return fmt.Sprintf("~%.0fs", seconds)
+	}
+	minutes := seconds / 60
+	return fmt.Sprintf("~%.1fm", minutes)
+}
+
 // SDStore is able to upload, download, and remove the contents of a Reader to the SD Store
 type SDStore interface {
 	Upload(u *url.URL, filePath string, toCompress bool, useExpectHeader bool) error
@@ -349,10 +388,24 @@ func (s *sdStore) request(url string, requestType string) ([]byte, error) {
 		return nil, fmt.Errorf("WARNING: received error from %s(%s): %v ", requestType, url, err)
 	}
 
+	// For GET requests, display file size and estimated download time
+	if requestType == "GET" && res.StatusCode/100 == 2 {
+		if contentLength := res.ContentLength; contentLength > 0 {
+			log.Printf("Downloading: %s (estimated time: %s)", formatBytes(contentLength), estimateTransferTime(contentLength, false))
+		}
+	}
+
+	startTime := time.Now()
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		log.Printf("reading response Body from Store API: %v", err)
 		return nil, fmt.Errorf("reading response Body from Store API: %v", err)
+	}
+
+	// Log actual download time for GET requests
+	if requestType == "GET" && res.StatusCode/100 == 2 && res.ContentLength > 0 {
+		elapsed := time.Since(startTime)
+		log.Printf("Download completed in %.2fs", elapsed.Seconds())
 	}
 
 	if res.StatusCode/100 != 2 {
@@ -390,10 +443,15 @@ func (s *sdStore) putFile(url *url.URL, bodyType string, filePath string, useExp
 		req.Header.Set("Expect", "100-continue")
 	}
 
+	var fileSize int64
 	if fi, err := os.Stat(filePath); err == nil {
 		req.ContentLength = fi.Size()
+		fileSize = fi.Size()
+		// Display file size and estimated upload time
+		log.Printf("Uploading: %s (estimated time: %s)", formatBytes(fileSize), estimateTransferTime(fileSize, true))
 	}
 
+	startTime := time.Now()
 	res, err := s.client.Do(req)
 	if res != nil {
 		defer res.Body.Close()
@@ -420,6 +478,12 @@ func (s *sdStore) putFile(url *url.URL, bodyType string, filePath string, useExp
 
 		log.Printf("WARNING: received response %d from %s ", res.StatusCode, url.String())
 		return fmt.Errorf("WARNING: received response %d from %s ", res.StatusCode, url.String())
+	}
+
+	// Log actual upload time
+	if fileSize > 0 {
+		elapsed := time.Since(startTime)
+		log.Printf("Upload completed in %.2fs", elapsed.Seconds())
 	}
 
 	return nil

--- a/store-cli.go
+++ b/store-cli.go
@@ -130,9 +130,6 @@ func makeURL(storeType, scope, key string) (*url.URL, error) {
 }
 
 func get(storeType, scope, key string, timeout int) error {
-	if skipCache(storeType, scope, "get") {
-		return nil
-	}
 
 	if strings.ToLower(storeType) == "cache" && CacheStrategy == "disk" {
 		return sdstore.Cache2Disk("get", scope, key, CacheMaxSizeInMB)


### PR DESCRIPTION
## Context

User would like to see the file size when uploading or downloading a file

## Objective

Show file size and upload/download time when using the get/set command for an object in cache

## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
